### PR TITLE
Fix image paths and replace placeholders

### DIFF
--- a/artists.html
+++ b/artists.html
@@ -19,7 +19,7 @@
         <i></i>
       </label>
       <div class="logo">
-        <a href="index.html"><img src="Img/placeholder_logo.png" alt="Label Logo" class="logo-img" style="height: 40px;"></a>
+        <a href="index.html"><img src="img/logo.png" alt="Label Logo" class="logo-img" style="height: 40px;"></a>
       </div>
       <div class="wide-nav">
         <ul>
@@ -47,28 +47,28 @@
       document.querySelector('main').classList.add('fade-out');
     </script>
     <div class="artist">
-      <img src="Img/placeholder_artist1.jpg" width="75%" alt="Artist Name 1">
+      <img src="img/brian.png" width="75%" alt="Artist Name 1">
       <h1>ARTIST NAME 1</h1>
     </div>
     <div class="artist-bio">
       Placeholder bio for Artist Name 1. This artist brings a unique sound to the scene... (Add more details here). Their latest album <strong>Album Title</strong> will be available on all streaming platforms (Date/Year).
     </div>
       <div class="artist">
-        <img src="Img/placeholder_artist2.jpg" width="75%" alt="Artist Name 2">
+        <img src="img/matt.png" width="75%" alt="Artist Name 2">
         <h1>ARTIST NAME 2</h1>
       </div>
       <div class="artist-bio">
         Placeholder bio for Artist Name 2. Known for their energetic performances and lyrical prowess... (Add more details here).
       </div>
       <div class="artist">
-        <img src="Img/placeholder_artist3.jpg" width="75%" alt="Artist Name 3">
+        <img src="img/mike.png" width="75%" alt="Artist Name 3">
         <h1>ARTIST NAME 3</h1>
       </div>
       <div class="artist-bio">
         Placeholder bio for Artist Name 3. A versatile artist and producer, contributing to various projects... (Add more details here).
       </div>
       <div class="artist">
-        <img src="Img/placeholder_artist4.jpg" width="75%" alt="Artist Name 4">
+        <img src="img/smurf.png" width="75%" alt="Artist Name 4">
         <h1>ARTIST NAME 4</h1>
       </div>
       <div class="artist-bio">

--- a/blog.html
+++ b/blog.html
@@ -17,7 +17,7 @@
         <i></i><i></i><i></i>
       </label>
       <div class="logo">
-        <a href="index.html"><img src="img/placeholder_logo.png" alt="Record Label Logo" class="logo-img"></a>
+        <a href="index.html"><img src="img/logo.png" alt="Record Label Logo" class="logo-img"></a>
       </div>
       <div class="wide-nav">
         <ul>

--- a/events.html
+++ b/events.html
@@ -18,7 +18,7 @@
         <i></i><i></i><i></i>
       </label>
       <div class="logo">
-         <a href="index.html"><img src="img/placeholder_logo.png" alt="Record Label Logo" class="logo-img"></a>
+         <a href="index.html"><img src="img/logo.png" alt="Record Label Logo" class="logo-img"></a>
       </div>
       <div class="wide-nav">
         <ul>

--- a/merch.html
+++ b/merch.html
@@ -18,7 +18,7 @@
         <i></i><i></i><i></i>
       </label>
       <div class="logo">
-        <a href="index.html"><img src="img/placeholder_logo.png" alt="Record Label Logo" class="logo-img"></a>
+        <a href="index.html"><img src="img/logo.png" alt="Record Label Logo" class="logo-img"></a>
       </div>
       <div class="wide-nav">
         <ul>
@@ -50,50 +50,50 @@
     <h1 class="page-title">Official Merchandise</h1>
 
     <div class="merch">
-      <img src="img/placeholder_merch1.jpg" width="200px" alt="Generic T-Shirt">
+      <img src="img/scoota-t.png" width="200px" alt="Generic T-Shirt">
       <h3>"LABEL LOGO TEE"</h3>
       <p>$25.00</p>
       <button>Add to Cart (Placeholder)</button>
     </div>
     <div class="merch">
-      <img src="img/placeholder_merch2.jpg" width="200px" alt="Generic Hoodie">
+      <img src="img/mark-t.png" width="200px" alt="Generic Hoodie">
       <h3>"ARTIST ALBUM HOODIE"</h3>
       <p>$45.00</p>
       <button>Add to Cart (Placeholder)</button>
     </div>
     <div class="merch">
-      <img src="img/placeholder_merch3.jpg" width="200px" alt="Generic Cap">
+      <img src="img/shrug-t.png" width="200px" alt="Generic Cap">
       <h3>"SIGNATURE CAP"</h3>
       <p>$20.00</p>
       <button>Add to Cart (Placeholder)</button>
     </div>
     <div class="merch">
-      <img src="img/placeholder_merch4.jpg" width="200px" alt="Limited Edition Item">
+      <img src="img/smurf-t.png" width="200px" alt="Limited Edition Item">
       <h3>"LIMITED EDITION PRINT"</h3>
       <p>$75.00</p>
       <p><em>Limited Edition</em></p>
       <button>Add to Cart (Placeholder)</button>
     </div>
     <div class="merch">
-      <img src="img/placeholder_merch5.jpg" width="200px" alt="Generic Beanie">
+      <img src="img/idk-ss.png" width="200px" alt="Generic Beanie">
       <h3>"WINTER BEANIE"</h3>
       <p>$18.00</p>
       <button>Add to Cart (Placeholder)</button>
     </div>
     <div class="merch">
-      <img src="img/placeholder_merch6.jpg" width="200px" alt="Generic Mug">
+      <img src="img/idk-long.png" width="200px" alt="Generic Mug">
       <h3>"LABEL LOGO MUG"</h3>
       <p>$15.00</p>
       <button>Add to Cart (Placeholder)</button>
     </div>
     <div class="merch">
-      <img src="img/placeholder_merch7.jpg" width="200px" alt="Generic Poster">
+      <img src="img/hurricane-t.png" width="200px" alt="Generic Poster">
       <h3>"TOUR POSTER"</h3>
       <p>$12.00</p>
       <button>Add to Cart (Placeholder)</button>
     </div>
     <div class="merch">
-      <img src="img/placeholder_merch8.jpg" width="200px" alt="Generic Vinyl">
+      <img src="img/hurricane-ls.png" width="200px" alt="Generic Vinyl">
       <h3>"ARTIST VINYL LP"</h3>
       <p>$30.00</p>
       <button>Add to Cart (Placeholder)</button>

--- a/shows.html
+++ b/shows.html
@@ -19,7 +19,7 @@
         <i></i>
       </label>
       <div class="logo">
-         <a href="index.html"><img src="Img/placeholder_logo.png" alt="Label Logo" class="logo-img" style="height: 40px;"></a>
+         <a href="index.html"><img src="img/logo.png" alt="Label Logo" class="logo-img" style="height: 40px;"></a>
       </div>
       <div class="wide-nav">
         <ul>


### PR DESCRIPTION
## Summary
- fix capitalized `Img/` path segments
- replace placeholder image filenames with real assets

## Testing
- `python3 - <<'PY'
import glob, re, os
missing=[]
for h in glob.glob('*.html'):
    with open(h) as f:
        content=f.read()
    for src in re.findall(r'src="(img/[^\"]+)"', content):
        if not os.path.exists(src):
            missing.append((h,src))
print('missing:', missing)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6840035c256483238a3be43247984b37