### PR TITLE
Improve layout

### DIFF
--- a/styles/home.css
+++ b/styles/home.css
@@ -45,17 +45,19 @@ header {
     background-color: #1c1c1c; /* Slightly lighter dark for header */
     padding: 0.5em 0; /* Adjust padding */
     border-bottom: 1px solid #333;
-    position: sticky; /* Makes header stick to top */
+    position: fixed; /* keep header fixed to the top */
     top: 0;
+    left: 0;
+    width: 100%;
     z-index: 1000; /* Ensure it's above other content */
 }
 
 nav {
     max-width: 1200px; /* Limit nav width */
     margin: 0 auto; /* Center nav */
-    padding: 0 20px; /* Padding inside nav */
+    padding: 0 20px 0 6rem; /* space for fixed logo */
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end; /* push items to the right */
     align-items: center;
 }
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -18,7 +18,7 @@ main {
   opacity: 1;
   transition: 1s opacity;
   display: grid;
-  margin-top: 3rem;
+  margin-top: 5rem; /* space for fixed header */
   font-size: 1.1rem;
 }
 
@@ -29,6 +29,7 @@ main.fade-out {
 
 main#home {
   grid-template-columns: auto;
+  min-height: 150vh; /* make home page longer */
 }
 
 main#home p {
@@ -83,20 +84,29 @@ main#merch {
   grid-gap: 7%;
 }
 
+header {
+  position: fixed; /* keep header at top */
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 1000;
+}
+
 nav {
-  padding: 1rem;
+  padding: 1rem 1rem 1rem 6rem; /* extra left padding for fixed logo */
   overflow: hidden;
   background-color: #fefefe;
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end; /* push navigation items to the right */
   align-items: center;
   text-transform: uppercase;
 }
 
 .logo {
-  position: absolute;
-  left: 3rem;
-
+  position: fixed; /* keep logo fixed in the top left */
+  top: 0.5rem;
+  left: 1rem;
+  z-index: 1001;
 }
 
 .logo a {
@@ -168,7 +178,10 @@ main {
 @media screen and (max-width: 700px) {
   .logo {
     padding: 0;
-    position: static;
+    position: fixed;
+    top: 0.5rem;
+    left: 1rem;
+    z-index: 1001;
   }
 
   .wide-nav {


### PR DESCRIPTION
## Summary
- keep header fixed at the top
- pin logo to the top left and align navigation on the right
- add extra spacing for the fixed header
- extend the home page height to make the page longer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684aca1423ec8323851c96923150618a