### PR TITLE
Remove stray Tailwind config text

### DIFF
--- a/blog-post1.html
+++ b/blog-post1.html
@@ -6,6 +6,7 @@
   <title>alafia ▸ Breaking the 1 % ceiling</title>
 
   <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+  <script>
     tailwind.config = { theme: { extend: { fontFamily: { sans: ['Inter','system-ui','sans-serif'] } } } };
   </script>
   <script defer src="https://unpkg.com/feather-icons"></script>

--- a/blog.html
+++ b/blog.html
@@ -6,6 +6,7 @@
   <title>alafia ▸ Blog</title>
 
   <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+  <script>
     tailwind.config = { theme: { extend: { fontFamily: { sans: ['Inter','system-ui','sans-serif'] } } } };
   </script>
   <script defer src="https://unpkg.com/feather-icons"></script>

--- a/event-1.html
+++ b/event-1.html
@@ -6,6 +6,7 @@
   <title>alafia ▸ Showcase Accra · 12 Sep 2025</title>
 
   <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+  <script>
     tailwind.config = { theme: { extend: { fontFamily: { sans: ['Inter','system-ui','sans-serif'] } } } };
   </script>
   <script defer src="https://unpkg.com/feather-icons"></script>

--- a/events.html
+++ b/events.html
@@ -6,6 +6,7 @@
   <title>alafia ▸ Events</title>
 
   <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+  <script>
     tailwind.config = { theme: { extend: { fontFamily: { sans: ['Inter','system-ui','sans-serif'] } } } };
   </script>
   <script defer src="https://unpkg.com/feather-icons"></script>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
 
   <!-- Tailwind 3 CDN -->
   <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+  <script>
     tailwind.config = {
       theme: {
         extend: { fontFamily: { sans: ['Inter','system-ui','sans-serif'] } }

--- a/playlists.html
+++ b/playlists.html
@@ -6,6 +6,7 @@
   <title>alafia ▸ Playlists</title>
 
   <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+  <script>
     tailwind.config = { theme: { extend: { fontFamily: { sans: ['Inter','system-ui','sans-serif'] } } } };
   </script>
   <script defer src="https://unpkg.com/feather-icons"></script>

--- a/roster.html
+++ b/roster.html
@@ -6,6 +6,7 @@
   <title>alafia ▸ Roster</title>
 
   <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+  <script>
     tailwind.config = { theme: { extend: { fontFamily: { sans: ['Inter','system-ui','sans-serif'] } } } };
   </script>
   <script defer src="https://unpkg.com/feather-icons"></script>


### PR DESCRIPTION
## Summary
- fix script tag so Tailwind config isn't displayed on pages

## Testing
- `grep -n "tailwind.config" -r . | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_684c7193171083239c9b7160015ceb60