### PR TITLE
Fix hero heading line breaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
 
     <div class="max-w-5xl mx-auto px-6 lg:px-8 pt-52 pb-60 text-center">
       <h1 class="text-4xl sm:text-7xl font-semibold tracking-tight leading-tight">
-        Powering Africa's Next Generation<br class="hidden sm:block">of Global Icons
+        Powering Africa's Next Generation<br class="hidden sm:block"><span class="whitespace-nowrap">of Global Icons</span>
       </h1>
       <p class="mt-8 text-lg leading-8 text-neutral-600">
         Your full-suite partner for commercial success. We provide integrated 


### PR DESCRIPTION
## Summary
- prevent line-wrapping inside "Global Icons" to ensure hero heading spans only two lines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f1ac259e8832397c9a873219772ed