### PR TITLE
Add embedded Apple Music playlists

### DIFF
--- a/playlists.html
+++ b/playlists.html
@@ -34,12 +34,12 @@
       Curated journeys through Afrobeats, Alté and everything in‑between.
     </p>
 
-      <div class="space-y-16">
+      <div class="grid gap-20">
         <!-- Ginger -->
         <div class="flex flex-col gap-4">
-          <div class="grid gap-4 sm:grid-cols-2">
-            <iframe title="Ginger playlist on Spotify" src="https://open.spotify.com/embed/playlist/2eb621QIoN0LPab3KqncUu?utm_source=generator" width="100%" height="450" frameborder="0" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"></iframe>
-            <iframe title="Ginger playlist on Apple Music" src="https://embed.music.apple.com/ng/playlist/gingerrrrrr/pl.u-06oxDB6uWBeJvYB" width="100%" height="450" frameborder="0" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-storage-access-by-user-activation allow-top-navigation-by-user-activation" allow="autoplay *; encrypted-media *; fullscreen *; clipboard-write"></iframe>
+          <div class="grid gap-4 md:grid-cols-2">
+            <iframe title="Ginger playlist on Spotify" src="https://open.spotify.com/embed/playlist/2eb621QIoN0LPab3KqncUu?utm_source=generator" width="100%" height="352" frameborder="0" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"></iframe>
+            <iframe title="Ginger playlist on Apple Music" src="https://embed.music.apple.com/ng/playlist/gingerrrrrr/pl.u-06oxDB6uWBeJvYB" width="100%" height="352" frameborder="0" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-storage-access-by-user-activation allow-top-navigation-by-user-activation" allow="autoplay *; encrypted-media *; fullscreen *; clipboard-write"></iframe>
           </div>
           <span class="font-medium">Ginger</span>
           <div class="flex gap-4 mt-2 text-neutral-500">
@@ -51,9 +51,9 @@
 
         <!-- I Know You Missed Me -->
         <div class="flex flex-col gap-4">
-          <div class="grid gap-4 sm:grid-cols-2">
-            <iframe title="I Know You Missed Me on Spotify" src="https://open.spotify.com/embed/playlist/4fioQsqmsRX4dRpFRdrF2d?utm_source=generator" width="100%" height="450" frameborder="0" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"></iframe>
-            <iframe title="I Know You Missed Me on Apple Music" src="https://embed.music.apple.com/ng/playlist/i-know-you-missed-me/pl.u-EdAVz8VuaEPvZDE" width="100%" height="450" frameborder="0" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-storage-access-by-user-activation allow-top-navigation-by-user-activation" allow="autoplay *; encrypted-media *; fullscreen *; clipboard-write"></iframe>
+          <div class="grid gap-4 md:grid-cols-2">
+            <iframe title="I Know You Missed Me on Spotify" src="https://open.spotify.com/embed/playlist/4fioQsqmsRX4dRpFRdrF2d?utm_source=generator" width="100%" height="352" frameborder="0" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"></iframe>
+            <iframe title="I Know You Missed Me on Apple Music" src="https://embed.music.apple.com/ng/playlist/i-know-you-missed-me/pl.u-EdAVz8VuaEPvZDE" width="100%" height="352" frameborder="0" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-storage-access-by-user-activation allow-top-navigation-by-user-activation" allow="autoplay *; encrypted-media *; fullscreen *; clipboard-write"></iframe>
           </div>
           <span class="font-medium">I Know You Missed Me</span>
           <div class="flex gap-4 mt-2 text-neutral-500">
@@ -65,9 +65,9 @@
 
         <!-- Lava Latte -->
         <div class="flex flex-col gap-4">
-          <div class="grid gap-4 sm:grid-cols-2">
-            <iframe title="Lava Latte on Spotify" src="https://open.spotify.com/embed/playlist/2WKwfUYg25YQ8lC33FIl0h?utm_source=generator" width="100%" height="450" frameborder="0" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"></iframe>
-            <iframe title="Lava Latte on Apple Music" src="https://embed.music.apple.com/ng/playlist/lava-latte/pl.u-XkD04XpHD3ABp23" width="100%" height="450" frameborder="0" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-storage-access-by-user-activation allow-top-navigation-by-user-activation" allow="autoplay *; encrypted-media *; fullscreen *; clipboard-write"></iframe>
+          <div class="grid gap-4 md:grid-cols-2">
+            <iframe title="Lava Latte on Spotify" src="https://open.spotify.com/embed/playlist/2WKwfUYg25YQ8lC33FIl0h?utm_source=generator" width="100%" height="352" frameborder="0" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"></iframe>
+            <iframe title="Lava Latte on Apple Music" src="https://embed.music.apple.com/ng/playlist/lava-latte/pl.u-XkD04XpHD3ABp23" width="100%" height="352" frameborder="0" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-storage-access-by-user-activation allow-top-navigation-by-user-activation" allow="autoplay *; encrypted-media *; fullscreen *; clipboard-write"></iframe>
           </div>
           <span class="font-medium">Lava Latte</span>
           <div class="flex gap-4 mt-2 text-neutral-500">


### PR DESCRIPTION
## Summary
- embed Apple Music playlist players next to Spotify players
- add labels to each playlist section
- arrange playlists vertically with spacing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f314110e88323a8effe0bdc0e9151