### PR TITLE
Fix gitignore to allow PNG tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-# Ignore all PNG images in the img directory
-img/*.png
+# Previously ignored all PNG images in the img directory.
+# img/*.png (allow PNG images to be tracked)


### PR DESCRIPTION
## Summary
- enable version control of PNG images in `img/`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685295659fdc8323a3b4237d6cb58ada