### PR TITLE
Separate current roster and alumni

### DIFF
--- a/alumni.html
+++ b/alumni.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Alafia Collective – Alumni</title>
+  <meta name="description" content="Artists who have been part of the Alafia Collective story." />
+  <meta property="og:title" content="Alafia Collective – Alumni">
+  <meta property="og:description" content="Artists who have been part of the Alafia Collective story.">
+  <meta property="og:image" content="img/rydm.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="canonical" href="https://alafia.me/alumni.html" />
+  <script>
+    tailwind.config = { theme: { extend: { fontFamily: { sans: ['Inter','system-ui','sans-serif'] } } } };
+  </script>
+  <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+  <script defer src="https://unpkg.com/feather-icons"></script>
+</head>
+<body class="pt-16 bg-white text-neutral-900 antialiased">
+  <header class="fixed top-0 left-0 z-50 w-full bg-white/90 backdrop-blur border-b border-neutral-200">
+    <div class="flex items-center h-16 px-6 lg:px-8">
+      <a href="index.html" class="mr-auto text-base font-semibold tracking-tight lowercase">the alafia collective</a>
+      <button id="navToggle" class="sm:hidden" aria-label="toggle menu"><i data-feather="menu"></i></button>
+      <ul id="menu" class="hidden absolute top-full inset-x-0 z-40 flex-col gap-4 p-6 text-base font-medium bg-white border-b border-neutral-200 sm:static sm:flex sm:flex-row sm:gap-8 sm:p-0 sm:border-0 sm:bg-transparent sm:text-sm">
+        <li><a href="roster.html" class="hover:underline">Roster</a></li>
+        <li><a href="playlists.html" class="hover:underline">Playlists</a></li>
+        <li><a href="events.html" class="hover:underline">Events</a></li>
+        <li><a href="blog.html" class="hover:underline">Blog</a></li>
+      </ul>
+    </div>
+  </header>
+
+  <main class="max-w-6xl mx-auto px-6 lg:px-8 pt-24 pb-32">
+    <h1 class="text-3xl font-semibold mb-4">Alumni</h1>
+    <p class="mb-12 text-neutral-700">Artists who have been part of the Alafia Collective story.</p>
+
+    <div class="grid gap-12 sm:grid-cols-2 lg:grid-cols-4">
+      <div class="flex flex-col gap-4">
+        <img src="img/rydm.jpg" alt="Rydm" class="aspect-square object-cover border border-neutral-200">
+        <span class="font-medium">Rydm</span>
+        <span class="text-sm text-neutral-600">Nigeria - Afrobeats, Rap, R&amp;B</span>
+        <div class="flex gap-4 mt-2 text-neutral-500">
+          <a href="https://open.spotify.com/artist/7LESUCcviSNkwCjlFqvhoQ?trackId=40ezsDqIIScN5MTYOz5Enj" aria-label="Spotify" target="_blank" rel="noopener noreferrer"><i data-feather="music"></i></a>
+          <a href="https://www.instagram.com/rydmjay" aria-label="Instagram" target="_blank" rel="noopener noreferrer"><i data-feather="instagram"></i></a>
+          <a href="https://x.com/feeltherydm" aria-label="X" target="_blank" rel="noopener noreferrer"><i data-feather="twitter"></i></a>
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-4">
+        <img src="img/nikita.png" alt="Nikita" class="aspect-square object-cover border border-neutral-200">
+        <span class="font-medium">Nikita</span>
+        <span class="text-sm text-neutral-600">Kenya - R&amp;B, Afrobeats, Soul</span>
+        <div class="flex gap-4 mt-2 text-neutral-500">
+          <a href="https://open.spotify.com/artist/1yQKzWOHXJQSEnOXrHDl4X" aria-label="Spotify" target="_blank" rel="noopener noreferrer"><i data-feather="music"></i></a>
+          <a href="https://www.instagram.com/nikita_kering/" aria-label="Instagram" target="_blank" rel="noopener noreferrer"><i data-feather="instagram"></i></a>
+          <a href="https://x.com/Nikita_Kering" aria-label="X" target="_blank" rel="noopener noreferrer"><i data-feather="twitter"></i></a>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">© 2025 the alafia collective</footer>
+  <script src="js/main.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -134,14 +134,6 @@
       </p>
       <div class="grid gap-12 sm:grid-cols-2 lg:grid-cols-4">
         <a href="roster.html" class="group flex flex-col gap-4">
-          <img src="img/rydm.jpg" alt="Rydm" class="aspect-square object-cover border border-neutral-200 group-hover:opacity-80 transition">
-          <span class="font-medium">Rydm</span>
-        </a>
-        <a href="roster.html" class="group flex flex-col gap-4">
-          <img src="img/nikita.png" alt="Nikita" class="aspect-square object-cover border border-neutral-200 group-hover:opacity-80 transition">
-          <span class="font-medium">Nikita</span>
-        </a>
-        <a href="roster.html" class="group flex flex-col gap-4">
           <img src="img/Trill-XOE.png" alt="Trill XOE" class="aspect-square object-cover border border-neutral-200 group-hover:opacity-80 transition">
           <span class="font-medium">Trill XOE</span>
         </a>

--- a/js/main.js
+++ b/js/main.js
@@ -160,12 +160,70 @@ document.addEventListener('DOMContentLoaded', () => {
     button { letter-spacing: .06em; text-transform: uppercase; }
     input:focus { --tw-ring-color: var(--alafia-ink) !important; }
 
-    footer {
-      padding-block: 2.4rem !important;
+    footer.alafia-footer {
+      padding: clamp(3rem, 6vw, 5.5rem) 1.5rem 1.5rem !important;
       background: var(--alafia-ink);
       border: 0 !important;
-      color: rgba(242, 240, 235, .62) !important;
+      color: rgba(242, 240, 235, .68) !important;
+      font-family: 'Plus Jakarta Sans', system-ui, sans-serif;
+      letter-spacing: normal;
+      text-align: left;
+      text-transform: none;
+    }
+    .alafia-footer__inner {
+      display: grid;
+      grid-template-columns: minmax(0, 1.6fr) minmax(12rem, 1fr);
+      gap: 3rem;
+      width: min(100%, 72rem);
+      margin: 0 auto;
+    }
+    .alafia-footer .alafia-brand {
+      margin-bottom: 1.2rem;
+      color: var(--alafia-paper) !important;
+    }
+    .alafia-footer__statement {
+      max-width: 28rem;
+      margin: 0;
+      color: rgba(242, 240, 235, .68);
+      font-size: .94rem;
+      line-height: 1.65;
+    }
+    .alafia-footer__label {
+      margin: 0 0 .9rem;
+      color: var(--alafia-accent);
       font-family: 'DM Mono', monospace;
+      font-size: .68rem;
+      font-weight: 500;
+      letter-spacing: .12em;
+      text-transform: uppercase;
+    }
+    .alafia-footer__links {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: .8rem 1.5rem;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+    .alafia-footer__links a {
+      color: var(--alafia-paper);
+      font-size: .84rem;
+      font-weight: 600;
+      letter-spacing: .03em;
+      text-decoration: none;
+    }
+    .alafia-footer__links a:hover { color: var(--alafia-accent); }
+    .alafia-footer__meta {
+      display: flex;
+      justify-content: space-between;
+      gap: 1rem;
+      width: min(100%, 72rem);
+      margin: clamp(2.5rem, 5vw, 4rem) auto 0;
+      padding-top: 1rem;
+      border-top: 1px solid rgba(242, 240, 235, .18);
+      color: rgba(242, 240, 235, .46);
+      font-family: 'DM Mono', monospace;
+      font-size: .65rem;
       letter-spacing: .08em;
       text-transform: uppercase;
     }
@@ -182,6 +240,10 @@ document.addEventListener('DOMContentLoaded', () => {
       .alafia-brand__wordmark { display: none; }
       .alafia-brand { gap: 0; }
       .relative.isolate.overflow-hidden.min-h-screen::after { right: -6rem; width: 18rem; height: 18rem; }
+      footer.alafia-footer { padding-inline: 1.5rem !important; }
+      .alafia-footer__inner { grid-template-columns: 1fr; gap: 2.5rem; }
+      .alafia-footer__links { grid-template-columns: repeat(3, minmax(0, 1fr)); gap: .8rem; }
+      .alafia-footer__meta { flex-direction: column; }
     }
   `;
   document.head.appendChild(siteStyles);
@@ -200,6 +262,32 @@ document.addEventListener('DOMContentLoaded', () => {
     const rosterItem = menu.querySelector('a[href="roster.html"]')?.closest('li');
     if (rosterItem) rosterItem.insertAdjacentElement('afterend', alumniItem);
     else menu.prepend(alumniItem);
+  }
+
+  const footer = document.querySelector('footer');
+  if (footer) {
+    footer.className = 'alafia-footer';
+    footer.innerHTML =
+      '<div class="alafia-footer__inner">' +
+        '<div>' +
+          '<a class="alafia-brand alafia-brand--inverse" href="index.html" aria-label="Alafia Collective home">' +
+            '<span class="alafia-brand__mark" aria-hidden="true"><svg viewBox="0 0 288 324" role="img" aria-label="Alafia X mark"><path fill="currentColor" fill-rule="evenodd" d="M0 0h64l22 74L111 0h58l23 74L224 0h64l-53 161 53 163h-64l-24-68-26 68h-64l-24-68-22 68H0l53-163ZM126 126h36l12 35-12 35h-36l-12-35Z" clip-rule="evenodd"/></svg></span>' +
+            '<span class="alafia-brand__wordmark">Alafia Collective</span>' +
+          '</a>' +
+          '<p class="alafia-footer__statement">Management, label services and publishing for Africa’s next generation of global icons.</p>' +
+        '</div>' +
+        '<div>' +
+          '<p class="alafia-footer__label">Explore</p>' +
+          '<ul class="alafia-footer__links">' +
+            '<li><a href="roster.html">Current Roster</a></li>' +
+            '<li><a href="alumni.html">Alumni</a></li>' +
+            '<li><a href="playlists.html">Playlists</a></li>' +
+            '<li><a href="events.html">Events</a></li>' +
+            '<li><a href="blog.html">Journal</a></li>' +
+          '</ul>' +
+        '</div>' +
+      '</div>' +
+      '<div class="alafia-footer__meta"><span>© ' + new Date().getFullYear() + ' Alafia Collective</span><span>Africa, without borders</span></div>';
   }
 
   if (window.feather) feather.replace();

--- a/js/main.js
+++ b/js/main.js
@@ -201,9 +201,17 @@ document.addEventListener('DOMContentLoaded', () => {
     brand.innerHTML = '<span class="alafia-brand__mark" aria-hidden="true"></span><span class="alafia-brand__wordmark">Alafia Collective</span>';
   }
 
+  const menu = document.getElementById('menu');
+  if (menu && !menu.querySelector('a[href="alumni.html"]')) {
+    const alumniItem = document.createElement('li');
+    alumniItem.innerHTML = '<a href="alumni.html" class="hover:underline">Alumni</a>';
+    const rosterItem = menu.querySelector('a[href="roster.html"]')?.closest('li');
+    if (rosterItem) rosterItem.insertAdjacentElement('afterend', alumniItem);
+    else menu.prepend(alumniItem);
+  }
+
   if (window.feather) feather.replace();
   const navToggle = document.getElementById('navToggle');
-  const menu = document.getElementById('menu');
   if (navToggle && menu) {
     navToggle.addEventListener('click', () => menu.classList.toggle('hidden'));
   }

--- a/js/main.js
+++ b/js/main.js
@@ -65,27 +65,19 @@ document.addEventListener('DOMContentLoaded', () => {
       text-transform: uppercase;
     }
     .alafia-brand__mark {
-      position: relative;
-      display: inline-block;
-      width: 35px;
-      height: 35px;
-      flex: 0 0 35px;
-      overflow: hidden;
-      background: var(--alafia-ink);
-      box-shadow: 4px 4px 0 var(--alafia-accent);
+      display: inline-flex;
+      width: 32px;
+      height: 36px;
+      flex: 0 0 32px;
+      color: var(--alafia-ink);
     }
-    .alafia-brand__mark::before,
-    .alafia-brand__mark::after {
-      position: absolute;
-      top: 3px;
-      left: 13px;
-      width: 8px;
-      height: 29px;
-      content: '';
-      background: var(--alafia-paper);
-      transform: rotate(34deg);
+    .alafia-brand__mark svg {
+      display: block;
+      width: 100%;
+      height: 100%;
     }
-    .alafia-brand__mark::after { transform: rotate(-34deg); }
+    .alafia-brand--inverse { color: var(--alafia-paper) !important; }
+    .alafia-brand--inverse .alafia-brand__mark { color: var(--alafia-paper); }
     .alafia-brand__wordmark { white-space: nowrap; }
 
     .relative.isolate.overflow-hidden.min-h-screen {
@@ -198,7 +190,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (brand) {
     brand.className = 'alafia-brand mr-auto';
     brand.setAttribute('aria-label', 'Alafia Collective home');
-    brand.innerHTML = '<span class="alafia-brand__mark" aria-hidden="true"></span><span class="alafia-brand__wordmark">Alafia Collective</span>';
+    brand.innerHTML = '<span class="alafia-brand__mark" aria-hidden="true"><svg viewBox="0 0 288 324" role="img" aria-label="Alafia X mark"><path fill="currentColor" fill-rule="evenodd" d="M0 0h64l22 74L111 0h58l23 74L224 0h64l-53 161 53 163h-64l-24-68-26 68h-64l-24-68-22 68H0l53-163ZM126 126h36l12 35-12 35h-36l-12-35Z" clip-rule="evenodd"/></svg></span><span class="alafia-brand__wordmark">Alafia Collective</span>';
   }
 
   const menu = document.getElementById('menu');

--- a/roster.html
+++ b/roster.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>The Alafia Collective – Africa's Future Global Icons</title>
+  <title>Alafia Collective – Current Roster</title>
   <meta name="description"
-        content="Meet our innovative Afrobeat and R&B artists shaping the future of African music." />
-  <meta property="og:title" content="The Alafia Collective – Africa's Future Global Icons">
-  <meta property="og:description" content="Meet our innovative Afrobeat and R&B artists shaping the future of African music.">
-  <meta property="og:image" content="img/rydm.jpg">
+        content="Meet the current Alafia Collective artists shaping the future of African music." />
+  <meta property="og:title" content="Alafia Collective – Current Roster">
+  <meta property="og:description" content="Meet the current Alafia Collective artists shaping the future of African music.">
+  <meta property="og:image" content="img/Trill-XOE.png">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="canonical" href="https://alafia.me/roster.html" />
 
@@ -34,36 +34,12 @@
   </header>
 
   <main class="max-w-6xl mx-auto px-6 lg:px-8 pt-24 pb-32">
-    <h1 class="text-3xl font-semibold mb-4">Our Roster</h1>
+    <h1 class="text-3xl font-semibold mb-4">Current Roster</h1>
     <p class="mb-12 text-neutral-700">
       Hand‑picked innovators shaping the next wave of African music.
     </p>
 
       <div class="grid gap-12 sm:grid-cols-2 lg:grid-cols-4">
-      <!-- Rydm -->
-      <div class="flex flex-col gap-4">
-        <img src="img/rydm.jpg" alt="Rydm" class="aspect-square object-cover border border-neutral-200">
-        <span class="font-medium">Rydm</span>
-        <span class="text-sm text-neutral-600">Nigeria - Afrobeats, Rap, R&amp;B</span>
-        <div class="flex gap-4 mt-2 text-neutral-500">
-          <a href="https://open.spotify.com/artist/7LESUCcviSNkwCjlFqvhoQ?trackId=40ezsDqIIScN5MTYOz5Enj" aria-label="Spotify"  target="_blank" rel="noopener noreferrer"><i data-feather="music"></i></a>
-          <a href="https://www.instagram.com/rydmjay" aria-label="Instagram" target="_blank" rel="noopener noreferrer"><i data-feather="instagram"></i></a>
-          <a href="https://x.com/feeltherydm" aria-label="X" target="_blank" rel="noopener noreferrer"><i data-feather="twitter"></i></a>
-        </div>
-      </div>
-
-      <!-- Nikita -->
-      <div class="flex flex-col gap-4">
-        <img src="img/nikita.png" alt="Nikita" class="aspect-square object-cover border border-neutral-200">
-        <span class="font-medium">Nikita</span>
-        <span class="text-sm text-neutral-600">Kenya - R&amp;B, Afrobeats, Soul</span>
-        <div class="flex gap-4 mt-2 text-neutral-500">
-          <a href="https://open.spotify.com/artist/1yQKzWOHXJQSEnOXrHDl4X" aria-label="Spotify"><i data-feather="music"></i></a>
-          <a href="https://www.instagram.com/nikita_kering/" aria-label="Instagram"><i data-feather="instagram"></i></a>
-          <a href="https://x.com/Nikita_Kering" aria-label="X"><i data-feather="twitter"></i></a>
-        </div>
-      </div>
-
       <!-- Trill XOE -->
       <div class="flex flex-col gap-4">
         <img src="img/Trill-XOE.png" alt="Trill XOE" class="aspect-square object-cover border border-neutral-200">


### PR DESCRIPTION
## What changed
- Turns `Roster` into the current artist roster.
- Adds a dedicated `Alumni` page for Nikita and Rydm, retaining their existing profile details and links.
- Removes Nikita and Rydm from the home-page current collective.
- Adds an Alumni link to the shared navigation.
- Replaces the earlier improvised crossed-bar logo with the approved geometric Alafia X mark, rendered as a responsive black/white SVG.
- Rebuilds the footer around the new brand direction, with Current Roster and Alumni links, all primary navigation, a concise collective description, and a dynamic copyright year.

## Validation
- Confirmed neither artist appears on the Current Roster or home-page current collective.
- Confirmed both artist profiles appear on the Alumni page.
- JavaScript syntax checked; the shared menu has a single declaration and the new logo and footer are present.