### PR TITLE
Prevent stale visual updates in browsers

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,0 +1,2 @@
+/js/main.js
+  Cache-Control: public, max-age=0, must-revalidate

--- a/alumni.html
+++ b/alumni.html
@@ -60,6 +60,6 @@
   </main>
 
   <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">© 2025 the alafia collective</footer>
-  <script src="js/main.js?v=20260712-2"></script>
+  <script src="js/main.js?v=20260712-3"></script>
 </body>
 </html>

--- a/blog-post4.html
+++ b/blog-post4.html
@@ -101,6 +101,6 @@ Congratulations Oluwa lo shey (Congratulations, to me, it was God that did it)</
   <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">
     © 2025 the alafia collective
   </footer>
-  <script src="js/main.js?v=20260712-2"></script>
+  <script src="js/main.js?v=20260712-3"></script>
 </body>
 </html>

--- a/blog-post5.html
+++ b/blog-post5.html
@@ -44,6 +44,6 @@
   <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">
     © 2025 the alafia collective
   </footer>
-  <script src="js/main.js?v=20260712-2"></script>
+  <script src="js/main.js?v=20260712-3"></script>
 </body>
 </html>

--- a/blog-post6.html
+++ b/blog-post6.html
@@ -101,6 +101,6 @@ Yes, me I’m stacking my doe oh like Kilimanjaro</p>
   <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">
     © 2025 the alafia collective
   </footer>
-  <script src="js/main.js?v=20260712-2"></script>
+  <script src="js/main.js?v=20260712-3"></script>
 </body>
 </html>

--- a/blog.html
+++ b/blog.html
@@ -72,6 +72,6 @@
     © 2025 the alafia collective
   </footer>
 
-  <script src="js/main.js?v=20260712-2"></script>
+  <script src="js/main.js?v=20260712-3"></script>
 </body>
 </html>

--- a/event-1.html
+++ b/event-1.html
@@ -60,6 +60,6 @@
     © 2025 the alafia collective
   </footer>
 
-  <script src="js/main.js?v=20260712-2"></script>
+  <script src="js/main.js?v=20260712-3"></script>
 </body>
 </html>

--- a/events.html
+++ b/events.html
@@ -88,6 +88,6 @@
     © 2025 the alafia collective
   </footer>
 
-  <script src="js/main.js?v=20260712-2"></script>
+  <script src="js/main.js?v=20260712-3"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -174,6 +174,6 @@
     © 2025 the alafia collective
   </footer>
 
-  <script src="js/main.js?v=20260712-2"></script>
+  <script src="js/main.js?v=20260712-3"></script>
 </body>
 </html>

--- a/playlists.html
+++ b/playlists.html
@@ -135,6 +135,6 @@
     © 2025 the alafia collective
   </footer>
 
-  <script src="js/main.js?v=20260712-2"></script>
+  <script src="js/main.js?v=20260712-3"></script>
 </body>
 </html>

--- a/roster.html
+++ b/roster.html
@@ -94,6 +94,6 @@
     © 2025 the alafia collective
   </footer>
 
-  <script src="js/main.js?v=20260712-2"></script>
+  <script src="js/main.js?v=20260712-3"></script>
 </body>
 </html>

--- a/rsvp-lagos.html
+++ b/rsvp-lagos.html
@@ -60,6 +60,6 @@
     © 2025 the alafia collective
   </footer>
 
-  <script src="js/main.js?v=20260712-2"></script>
+  <script src="js/main.js?v=20260712-3"></script>
 </body>
 </html>

--- a/whatsleft.html
+++ b/whatsleft.html
@@ -31,6 +31,6 @@
     </div>
   </div>
   <footer class="text-sm text-neutral-500">© 2025 the alafia collective</footer>
-  <script src="js/main.js?v=20260712-2"></script>
+  <script src="js/main.js?v=20260712-3"></script>
 </body>
 </html>


### PR DESCRIPTION
Ensures the hero readability fix and future shared-style changes are seen immediately.

- Bumps every static page to `js/main.js?v=20260712-3`.
- Adds Cloudflare Pages cache headers so `js/main.js` revalidates rather than being held for four hours.

Validation: all 12 pages reference the new script version and the cache header is present.