### PR TITLE
Rebrand public site text to Alafia

### DIFF
--- a/alumni.html
+++ b/alumni.html
@@ -60,6 +60,6 @@
   </main>
 
   <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">© 2025 Alafia</footer>
-  <script src="js/main.js?v=20260712-3"></script>
+  <script src="js/main.js?v=20260712-4"></script>
 </body>
 </html>

--- a/alumni.html
+++ b/alumni.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Alafia Collective – Alumni</title>
-  <meta name="description" content="Artists who have been part of the Alafia Collective story." />
-  <meta property="og:title" content="Alafia Collective – Alumni">
-  <meta property="og:description" content="Artists who have been part of the Alafia Collective story.">
+  <title>Alafia – Alumni</title>
+  <meta name="description" content="Artists who have been part of the Alafia story." />
+  <meta property="og:title" content="Alafia – Alumni">
+  <meta property="og:description" content="Artists who have been part of the Alafia story.">
   <meta property="og:image" content="img/rydm.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="canonical" href="https://alafia.me/alumni.html" />
@@ -19,7 +19,7 @@
 <body class="pt-16 bg-white text-neutral-900 antialiased">
   <header class="fixed top-0 left-0 z-50 w-full bg-white/90 backdrop-blur border-b border-neutral-200">
     <div class="flex items-center h-16 px-6 lg:px-8">
-      <a href="index.html" class="mr-auto text-base font-semibold tracking-tight lowercase">the alafia collective</a>
+      <a href="index.html" class="mr-auto text-base font-semibold tracking-tight lowercase">Alafia</a>
       <button id="navToggle" class="sm:hidden" aria-label="toggle menu"><i data-feather="menu"></i></button>
       <ul id="menu" class="hidden absolute top-full inset-x-0 z-40 flex-col gap-4 p-6 text-base font-medium bg-white border-b border-neutral-200 sm:static sm:flex sm:flex-row sm:gap-8 sm:p-0 sm:border-0 sm:bg-transparent sm:text-sm">
         <li><a href="roster.html" class="hover:underline">Roster</a></li>
@@ -32,7 +32,7 @@
 
   <main class="max-w-6xl mx-auto px-6 lg:px-8 pt-24 pb-32">
     <h1 class="text-3xl font-semibold mb-4">Alumni</h1>
-    <p class="mb-12 text-neutral-700">Artists who have been part of the Alafia Collective story.</p>
+    <p class="mb-12 text-neutral-700">Artists who have been part of the Alafia story.</p>
 
     <div class="grid gap-12 sm:grid-cols-2 lg:grid-cols-4">
       <div class="flex flex-col gap-4">
@@ -59,7 +59,7 @@
     </div>
   </main>
 
-  <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">© 2025 the alafia collective</footer>
+  <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">© 2025 Alafia</footer>
   <script src="js/main.js?v=20260712-3"></script>
 </body>
 </html>

--- a/blog-post4.html
+++ b/blog-post4.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Introducing Rydm &amp; Alafia Collective: My First Jam Session – The Alafia Collective Blog</title>
-  <meta name="description" content="Temitope recounts meeting Rydm Jay and the jam sessions that sparked Alafia Collective." />
-  <meta property="og:title" content="Introducing Rydm & Alafia Collective: My First Jam Session – The Alafia Collective Blog">
-  <meta property="og:description" content="Temitope recounts meeting Rydm Jay and the jam sessions that sparked Alafia Collective.">
+  <title>Introducing Rydm &amp; Alafia: My First Jam Session – Alafia Blog</title>
+  <meta name="description" content="Temitope recounts meeting Rydm Jay and the jam sessions that sparked Alafia." />
+  <meta property="og:title" content="Introducing Rydm & Alafia: My First Jam Session – Alafia Blog">
+  <meta property="og:description" content="Temitope recounts meeting Rydm Jay and the jam sessions that sparked Alafia.">
   <meta property="og:image" content="img/rydm.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="canonical" href="https://alafia.me/blog-post4.html" />
@@ -19,7 +19,7 @@
 <body class="pt-16 bg-white text-neutral-900 antialiased">
   <header class="fixed top-0 left-0 z-50 w-full bg-white/90 backdrop-blur border-b border-neutral-200">
     <div class="flex items-center h-16 px-6 lg:px-8">
-      <a href="index.html" class="mr-auto text-base font-semibold tracking-tight lowercase">the alafia collective</a>
+      <a href="index.html" class="mr-auto text-base font-semibold tracking-tight lowercase">Alafia</a>
       <button id="navToggle" class="sm:hidden" aria-label="toggle menu"><i data-feather="menu"></i></button>
       <ul id="menu" class="hidden absolute top-full inset-x-0 z-40 flex-col gap-4 p-6 text-base font-medium bg-white border-b border-neutral-200 sm:static sm:flex sm:flex-row sm:gap-8 sm:p-0 sm:border-0 sm:bg-transparent sm:text-sm">
         <li><a href="roster.html"    class="hover:underline">Roster</a></li>
@@ -30,7 +30,7 @@
     </div>
   </header>
   <main class="prose lg:prose-lg mx-auto px-6 lg:px-8 pt-24 pb-32">
-    <h1>Introducing Rydm &amp; Alafia Collective: My First Jam Session</h1>
+    <h1>Introducing Rydm &amp; Alafia: My First Jam Session</h1>
     <p class="text-sm text-neutral-600">15 December 2024 · 3 min read</p>
 <p>Welcome to the team, Rydm Jay! We are huge fans of the music you're making. We're young people striving to bring structure to the music industry, empowering young artists to share their talent with the world.</p>
 
@@ -39,7 +39,7 @@
 <p>His first single, "Okay," is out now, and I'm incredibly excited. You can find it on major DSPs <a href="https://open.spotify.com/album/43b45gW3L2w5unxYy1d752?si=bb0967a549044d08" target="_blank" rel="noopener noreferrer">here</a>. Please give it a listen!</p>
 
 <h2>How My Love for Music Grew</h2>
-<p>I'm building Alafia Collective with my team because I genuinely love music. A lot. But I wasn't always this passionate.</p>
+<p>I'm building Alafia with my team because I genuinely love music. A lot. But I wasn't always this passionate.</p>
 <p>Sometimes, I wish the story of how I developed my love for music was profound. But like love, growth, and a good song, my story is one of milestones and moments. Here are the key milestones:</p>
 
 <h3>1. I Wasn't Always So Into Music</h3>
@@ -99,7 +99,7 @@ Congratulations Oluwa lo shey (Congratulations, to me, it was God that did it)</
 <p>Have a nice one and take care of the baddies!</p>
   </main>
   <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">
-    © 2025 the alafia collective
+    © 2025 Alafia
   </footer>
   <script src="js/main.js?v=20260712-3"></script>
 </body>

--- a/blog-post4.html
+++ b/blog-post4.html
@@ -101,6 +101,6 @@ Congratulations Oluwa lo shey (Congratulations, to me, it was God that did it)</
   <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">
     © 2025 Alafia
   </footer>
-  <script src="js/main.js?v=20260712-3"></script>
+  <script src="js/main.js?v=20260712-4"></script>
 </body>
 </html>

--- a/blog-post5.html
+++ b/blog-post5.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>From Consulting to the Alafia Collective – The Alafia Collective Blog</title>
-  <meta name="description" content="Temitope shares his path from management consulting ambitions to launching Alafia Collective." />
+  <title>From Consulting to the Alafia – Alafia Blog</title>
+  <meta name="description" content="Temitope shares his path from management consulting ambitions to launching Alafia." />
   <link rel="canonical" href="https://alafia.me/blog-post5.html" />
-  <meta property="og:title" content="From Consulting to the Alafia Collective – The Alafia Collective Blog">
-  <meta property="og:description" content="Temitope shares his path from management consulting ambitions to launching Alafia Collective.">
+  <meta property="og:title" content="From Consulting to the Alafia – Alafia Blog">
+  <meta property="og:description" content="Temitope shares his path from management consulting ambitions to launching Alafia.">
   <meta property="og:image" content="img/rydm.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <script>
@@ -19,7 +19,7 @@
 <body class="pt-16 bg-white text-neutral-900 antialiased">
   <header class="fixed top-0 left-0 z-50 w-full bg-white/90 backdrop-blur border-b border-neutral-200">
     <div class="flex items-center h-16 px-6 lg:px-8">
-      <a href="index.html" class="mr-auto text-base font-semibold tracking-tight lowercase">the alafia collective</a>
+      <a href="index.html" class="mr-auto text-base font-semibold tracking-tight lowercase">Alafia</a>
       <button id="navToggle" class="sm:hidden" aria-label="toggle menu"><i data-feather="menu"></i></button>
       <ul id="menu" class="hidden absolute top-full inset-x-0 z-40 flex-col gap-4 p-6 text-base font-medium bg-white border-b border-neutral-200 sm:static sm:flex sm:flex-row sm:gap-8 sm:p-0 sm:border-0 sm:bg-transparent sm:text-sm">
         <li><a href="roster.html"    class="hover:underline">Roster</a></li>
@@ -30,19 +30,19 @@
     </div>
   </header>
   <main class="prose lg:prose-lg mx-auto px-6 lg:px-8 pt-24 pb-32">
-    <h1>From Consulting to the Alafia Collective</h1>
+    <h1>From Consulting to the Alafia</h1>
     <p class="text-sm text-neutral-600">20 January 2025 · 2 min read</p>
-    <p>Hello! At one point in life, I was convinced I wanted to become a managing partner at a consulting firm; ten years later, I’m running a record label with my bestie from university. After the blood, sweat, and tears, I’d like to present to you Alafia Collective. In one line, our vision is to power Africa’s next generation of global icons.</p>
+    <p>Hello! At one point in life, I was convinced I wanted to become a managing partner at a consulting firm; ten years later, I’m running a record label with my bestie from university. After the blood, sweat, and tears, I’d like to present to you Alafia. In one line, our vision is to power Africa’s next generation of global icons.</p>
     <p>In 2019, I was using sparkline formulas to create automated timelines and Gantt charts for artists and their teams.</p>
     <p>In 2020, Trill Xoe, one of Nigeria’s finest producers, gave me the opportunity to be his full-time manager. In that time, Trillo became the most sought-after producer, crafting the number-one song in the country. The song, “Declan Rice,” went on to become the official announcement track for England and Arsenal star Declan Rice.</p>
     <p>By 2023, Mubarak Osman, Julian Mason, and I crystallised what we call the Paradox of Access: creating and distributing music is easier than ever, but breaking through the clutter is harder than ever.</p>
-    <p>Alafia Collective provides integrated management, label services, and publishing solutions that elevate African talent into global powerhouses. Currently, our roster boasts Billboard-charting producer EJ FYA (“Talibans” – Byron Messia ft. Burna Boy), Kenya’s pop sensation Nikita Kering’, Rydm (new Starboy), Mide the Goat, and Saezn (Africa’s R&B sensation).</p>
+    <p>Alafia provides integrated management, label services, and publishing solutions that elevate African talent into global powerhouses. Currently, our roster boasts Billboard-charting producer EJ FYA (“Talibans” – Byron Messia ft. Burna Boy), Kenya’s pop sensation Nikita Kering’, Rydm (new Starboy), Mide the Goat, and Saezn (Africa’s R&B sensation).</p>
     <p>Kindly check out our website <a href="https://alafia.me" target="_blank" rel="noopener">alafia.me</a>. I would love to chat with people in the music, entertainment, and PR spaces – I need visibility for my artists!</p>
     <p>My label act drops new music in two days—music like you’ve never heard before. Some call me the Pep Guardiola of music, and I’m happy to share the gems we’ve been cooking with interested parties.</p>
     <p><a href="https://www.linkedin.com/posts/activity-7341129193356685312-8nXv?" target="_blank" rel="noopener">View this post on LinkedIn</a></p>
   </main>
   <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">
-    © 2025 the alafia collective
+    © 2025 Alafia
   </footer>
   <script src="js/main.js?v=20260712-3"></script>
 </body>

--- a/blog-post5.html
+++ b/blog-post5.html
@@ -44,6 +44,6 @@
   <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">
     © 2025 Alafia
   </footer>
-  <script src="js/main.js?v=20260712-3"></script>
+  <script src="js/main.js?v=20260712-4"></script>
 </body>
 </html>

--- a/blog-post6.html
+++ b/blog-post6.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Gospel Artists With A Popstar Calling – The Alafia Collective Blog</title>
+  <title>Gospel Artists With A Popstar Calling – Alafia Blog</title>
   <meta name="description" content="Your Fave explores spiritual themes in Black Sherif's music and how it inspires him." />
   <link rel="canonical" href="https://alafia.me/blog-post6.html" />
-  <meta property="og:title" content="Gospel Artists With A Popstar Calling – The Alafia Collective Blog">
+  <meta property="og:title" content="Gospel Artists With A Popstar Calling – Alafia Blog">
   <meta property="og:description" content="Your Fave explores spiritual themes in Black Sherif's music and how it inspires him.">
   <meta property="og:image" content="img/rydm.jpg">
   <meta name="twitter:card" content="summary_large_image">
@@ -19,7 +19,7 @@
 <body class="pt-16 bg-white text-neutral-900 antialiased">
   <header class="fixed top-0 left-0 z-50 w-full bg-white/90 backdrop-blur border-b border-neutral-200">
     <div class="flex items-center h-16 px-6 lg:px-8">
-      <a href="index.html" class="mr-auto text-base font-semibold tracking-tight lowercase">the alafia collective</a>
+      <a href="index.html" class="mr-auto text-base font-semibold tracking-tight lowercase">Alafia</a>
       <button id="navToggle" class="sm:hidden" aria-label="toggle menu"><i data-feather="menu"></i></button>
       <ul id="menu" class="hidden absolute top-full inset-x-0 z-40 flex-col gap-4 p-6 text-base font-medium bg-white border-b border-neutral-200 sm:static sm:flex sm:flex-row sm:gap-8 sm:p-0 sm:border-0 sm:bg-transparent sm:text-sm">
         <li><a href="roster.html"    class="hover:underline">Roster</a></li>
@@ -99,7 +99,7 @@ Yes, me I’m stacking my doe oh like Kilimanjaro</p>
   </div>
 </main>
   <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">
-    © 2025 the alafia collective
+    © 2025 Alafia
   </footer>
   <script src="js/main.js?v=20260712-3"></script>
 </body>

--- a/blog-post6.html
+++ b/blog-post6.html
@@ -101,6 +101,6 @@ Yes, me I’m stacking my doe oh like Kilimanjaro</p>
   <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">
     © 2025 Alafia
   </footer>
-  <script src="js/main.js?v=20260712-3"></script>
+  <script src="js/main.js?v=20260712-4"></script>
 </body>
 </html>

--- a/blog.html
+++ b/blog.html
@@ -22,7 +22,7 @@
 <body class="pt-16 bg-white text-neutral-900 antialiased">
   <header class="fixed top-0 left-0 z-50 w-full bg-white/90 backdrop-blur border-b border-neutral-200">
     <div class="flex items-center h-16 px-6 lg:px-8">
-      <a href="index.html" class="mr-auto text-base font-semibold tracking-tight lowercase">the alafia collective</a>
+      <a href="index.html" class="mr-auto text-base font-semibold tracking-tight lowercase">Alafia</a>
       <button id="navToggle" class="sm:hidden" aria-label="toggle menu"><i data-feather="menu"></i></button>
       <ul id="menu" class="hidden absolute top-full inset-x-0 z-40 flex-col gap-4 p-6 text-base font-medium bg-white border-b border-neutral-200 sm:static sm:flex sm:flex-row sm:gap-8 sm:p-0 sm:border-0 sm:bg-transparent sm:text-sm">
         <li><a href="roster.html"    class="hover:underline">Roster</a></li>
@@ -49,7 +49,7 @@
         </a>
       </article>
       <article class="flex flex-col gap-4">
-        <h2 class="text-2xl font-medium"><a href="blog-post5.html" class="hover:underline">From Consulting to the Alafia Collective</a></h2>
+        <h2 class="text-2xl font-medium"><a href="blog-post5.html" class="hover:underline">From Consulting to the Alafia</a></h2>
         <p class="text-sm text-neutral-600">20 Jan 2025 · 2 min read</p>
         <p class="prose max-w-none text-neutral-800">Temitope shares his journey from spreadsheets to launching a record label and invites industry collaborators.</p>
         <a href="blog-post5.html" class="inline-flex items-center gap-1 text-sm font-medium hover:underline">
@@ -58,7 +58,7 @@
       </article>
 
       <article class="flex flex-col gap-4">
-        <h2 class="text-2xl font-medium"><a href="blog-post4.html" class="hover:underline">Introducing Rydm &amp; Alafia Collective: My First Jam Session</a></h2>
+        <h2 class="text-2xl font-medium"><a href="blog-post4.html" class="hover:underline">Introducing Rydm &amp; Alafia: My First Jam Session</a></h2>
         <p class="text-sm text-neutral-600">15 Dec 2024 · 10 min read</p>
         <p class="prose max-w-none text-neutral-800">Temitope traces the collective's origins, from first jam sessions to welcoming Rydm Jay.</p>
         <a href="blog-post4.html" class="inline-flex items-center gap-1 text-sm font-medium hover:underline">
@@ -69,7 +69,7 @@
   </main>
 
   <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">
-    © 2025 the alafia collective
+    © 2025 Alafia
   </footer>
 
   <script src="js/main.js?v=20260712-3"></script>

--- a/blog.html
+++ b/blog.html
@@ -72,6 +72,6 @@
     © 2025 Alafia
   </footer>
 
-  <script src="js/main.js?v=20260712-3"></script>
+  <script src="js/main.js?v=20260712-4"></script>
 </body>
 </html>

--- a/event-1.html
+++ b/event-1.html
@@ -60,6 +60,6 @@
     © 2025 Alafia
   </footer>
 
-  <script src="js/main.js?v=20260712-3"></script>
+  <script src="js/main.js?v=20260712-4"></script>
 </body>
 </html>

--- a/event-1.html
+++ b/event-1.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Sounds of the City — Accra · Q4 2025 – The Alafia Collective</title>
+  <title>Sounds of the City — Accra · Q4 2025 – Alafia</title>
   <meta name="description"
         content="Join Nikita Kering’, Trill Xoe and Mide The Goat live in Accra to celebrate the future of African music." />
-  <meta property="og:title" content="Sounds of the City — Accra · 12 Sep 2025 – The Alafia Collective">
+  <meta property="og:title" content="Sounds of the City — Accra · 12 Sep 2025 – Alafia">
   <meta property="og:description" content="Join Nikita Kering’, Trill Xoe and Mide The Goat live in Accra to celebrate the future of African music.">
   <meta property="og:image" content="img/Sounds.png">
   <meta name="twitter:card" content="summary_large_image">
@@ -22,7 +22,7 @@
 <body class="pt-16 bg-white text-neutral-900 antialiased">
   <header class="fixed top-0 left-0 z-50 w-full bg-white/90 backdrop-blur border-b border-neutral-200">
     <div class="flex items-center h-16 px-6 lg:px-8">
-      <a href="index.html" class="mr-auto text-base font-semibold tracking-tight lowercase">the alafia collective</a>
+      <a href="index.html" class="mr-auto text-base font-semibold tracking-tight lowercase">Alafia</a>
       <button id="navToggle" class="sm:hidden" aria-label="toggle menu"><i data-feather="menu"></i></button>
       <ul id="menu" class="hidden absolute top-full inset-x-0 z-40 flex-col gap-4 p-6 text-base font-medium bg-white border-b border-neutral-200 sm:static sm:flex sm:flex-row sm:gap-8 sm:p-0 sm:border-0 sm:bg-transparent sm:text-sm">
         <li><a href="roster.html"    class="hover:underline">Roster</a></li>
@@ -57,7 +57,7 @@
   </main>
 
   <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">
-    © 2025 the alafia collective
+    © 2025 Alafia
   </footer>
 
   <script src="js/main.js?v=20260712-3"></script>

--- a/events.html
+++ b/events.html
@@ -88,6 +88,6 @@
     © 2025 Alafia
   </footer>
 
-  <script src="js/main.js?v=20260712-3"></script>
+  <script src="js/main.js?v=20260712-4"></script>
 </body>
 </html>

--- a/events.html
+++ b/events.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Alafia Live – Showcasing Tomorrow's Global African Icons</title>
   <meta name="description"
-        content="Experience The Alafia Collective talent on stage from Lagos block parties to global festivals. See upcoming shows." />
+        content="Experience Alafia talent on stage from Lagos block parties to global festivals. See upcoming shows." />
   <meta property="og:title" content="Alafia Live – Showcasing Tomorrow's Global African Icons">
-  <meta property="og:description" content="Experience The Alafia Collective talent on stage from Lagos block parties to global festivals. See upcoming shows.">
+  <meta property="og:description" content="Experience Alafia talent on stage from Lagos block parties to global festivals. See upcoming shows.">
   <meta property="og:image" content="img/Sounds.png">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="canonical" href="https://alafia.me/events.html" />
@@ -22,7 +22,7 @@
 <body class="pt-16 bg-white text-neutral-900 antialiased">
   <header class="fixed top-0 left-0 z-50 w-full bg-white/90 backdrop-blur border-b border-neutral-200">
     <div class="flex items-center h-16 px-6 lg:px-8">
-      <a href="index.html" class="mr-auto text-base font-semibold tracking-tight lowercase">the alafia collective</a>
+      <a href="index.html" class="mr-auto text-base font-semibold tracking-tight lowercase">Alafia</a>
       <button id="navToggle" class="sm:hidden" aria-label="toggle menu"><i data-feather="menu"></i></button>
       <ul id="menu" class="hidden absolute top-full inset-x-0 z-40 flex-col gap-4 p-6 text-base font-medium bg-white border-b border-neutral-200 sm:static sm:flex sm:flex-row sm:gap-8 sm:p-0 sm:border-0 sm:bg-transparent sm:text-sm">
         <li><a href="roster.html"    class="hover:underline">Roster</a></li>
@@ -36,7 +36,7 @@
   <main class="max-w-4xl mx-auto px-6 lg:px-8 pt-24 pb-32">
     <h1 class="text-3xl font-semibold mb-4">Live Events</h1>
     <p class="mb-12 text-neutral-700">
-      Experience The Alafia Collective talent on stage — from Lagos block parties to global festival main‑stages.
+      Experience Alafia talent on stage — from Lagos block parties to global festival main‑stages.
     </p>
 
       <div class="space-y-12">
@@ -85,7 +85,7 @@
   </main>
 
   <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">
-    © 2025 the alafia collective
+    © 2025 Alafia
   </footer>
 
   <script src="js/main.js?v=20260712-3"></script>

--- a/index.html
+++ b/index.html
@@ -174,6 +174,6 @@
     © 2025 Alafia
   </footer>
 
-  <script src="js/main.js?v=20260712-3"></script>
+  <script src="js/main.js?v=20260712-4"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Alafia – Powering Africa's Next Generation of Global Icons</title>
   <meta name="description"
-        content="The Alafia Collective provides integrated management, label services and publishing for emerging African artists. Explore our roster, playlists and events." />
+        content="Alafia provides integrated management, label services and publishing for emerging African artists. Explore our roster, playlists and events." />
   <meta property="og:title" content="Alafia – Powering Africa's Next Generation of Global Icons">
-  <meta property="og:description" content="The Alafia Collective provides integrated management, label services and publishing for emerging African artists. Explore our roster, playlists and events.">
+  <meta property="og:description" content="Alafia provides integrated management, label services and publishing for emerging African artists. Explore our roster, playlists and events.">
   <meta property="og:image" content="img/Announcement.png">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="canonical" href="https://alafia.me/" />
@@ -30,7 +30,7 @@
   <!-- Header -->
   <header class="fixed top-0 left-0 z-50 w-full bg-white/90 backdrop-blur border-b border-neutral-200">
     <div class="flex items-center h-16 px-6 lg:px-8">
-      <a href="index.html" class="mr-auto text-base font-semibold tracking-tight lowercase">The Alafia Collective</a>
+      <a href="index.html" class="mr-auto text-base font-semibold tracking-tight lowercase">Alafia</a>
       <button id="navToggle" class="sm:hidden" aria-label="toggle menu"><i data-feather="menu"></i></button>
       <ul id="menu" class="hidden absolute top-full inset-x-0 z-40 flex-col gap-4 p-6 text-base font-medium bg-white border-b border-neutral-200 sm:static sm:flex sm:flex-row sm:gap-8 sm:p-0 sm:border-0 sm:bg-transparent sm:text-sm">
         <li><a href="roster.html"    class="hover:underline">Roster</a></li>
@@ -171,7 +171,7 @@
 
   <!-- Footer -->
   <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">
-    © 2025 the alafia collective
+    © 2025 Alafia
   </footer>
 
   <script src="js/main.js?v=20260712-3"></script>

--- a/js/main.js
+++ b/js/main.js
@@ -280,8 +280,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const brand = document.querySelector('header a[href="index.html"]');
   if (brand) {
     brand.className = 'alafia-brand mr-auto';
-    brand.setAttribute('aria-label', 'Alafia Collective home');
-    brand.innerHTML = '<span class="alafia-brand__mark" aria-hidden="true"><img src="img/alafia-x-mark.svg" alt="" /></span><span class="alafia-brand__wordmark">Alafia Collective</span>';
+    brand.setAttribute('aria-label', 'Alafia home');
+    brand.innerHTML = '<span class="alafia-brand__mark" aria-hidden="true"><img src="img/alafia-x-mark.svg" alt="" /></span><span class="alafia-brand__wordmark">Alafia</span>';
   }
 
   const menu = document.getElementById('menu');
@@ -299,9 +299,9 @@ document.addEventListener('DOMContentLoaded', () => {
     footer.innerHTML =
       '<div class="alafia-footer__inner">' +
         '<div>' +
-          '<a class="alafia-brand alafia-brand--inverse" href="index.html" aria-label="Alafia Collective home">' +
+          '<a class="alafia-brand alafia-brand--inverse" href="index.html" aria-label="Alafia home">' +
             '<span class="alafia-brand__mark" aria-hidden="true"><img src="img/alafia-x-mark.svg" alt="" /></span>' +
-            '<span class="alafia-brand__wordmark">Alafia Collective</span>' +
+            '<span class="alafia-brand__wordmark">Alafia</span>' +
           '</a>' +
           '<p class="alafia-footer__statement">Building lasting careers for African artists, songwriters and producers.</p>' +
           '<p class="alafia-footer__services">Management · Label Services · Publishing</p>' +
@@ -317,7 +317,7 @@ document.addEventListener('DOMContentLoaded', () => {
           '</ul>' +
         '</div>' +
       '</div>' +
-      '<div class="alafia-footer__meta"><span>© 2026 Alafia Collective. All rights reserved.</span><span>Independent music infrastructure for Africa.</span></div>';
+      '<div class="alafia-footer__meta"><span>© 2026 Alafia. All rights reserved.</span><span>Independent music infrastructure for Africa.</span></div>';
   }
 
   if (window.feather) feather.replace();

--- a/playlists.html
+++ b/playlists.html
@@ -135,6 +135,6 @@
     © 2025 Alafia
   </footer>
 
-  <script src="js/main.js?v=20260712-3"></script>
+  <script src="js/main.js?v=20260712-4"></script>
 </body>
 </html>

--- a/playlists.html
+++ b/playlists.html
@@ -22,7 +22,7 @@
 <body class="pt-16 bg-white text-neutral-900 antialiased">
   <header class="fixed top-0 left-0 z-50 w-full bg-white/90 backdrop-blur border-b border-neutral-200">
     <div class="flex items-center h-16 px-6 lg:px-8">
-      <a href="index.html" class="mr-auto text-base font-semibold tracking-tight lowercase">the alafia collective</a>
+      <a href="index.html" class="mr-auto text-base font-semibold tracking-tight lowercase">Alafia</a>
       <button id="navToggle" class="sm:hidden" aria-label="toggle menu"><i data-feather="menu"></i></button>
       <ul id="menu" class="hidden absolute top-full inset-x-0 z-40 flex-col gap-4 p-6 text-base font-medium bg-white border-b border-neutral-200 sm:static sm:flex sm:flex-row sm:gap-8 sm:p-0 sm:border-0 sm:bg-transparent sm:text-sm">
         <li><a href="roster.html"    class="hover:underline">Roster</a></li>
@@ -132,7 +132,7 @@
   </main>
 
   <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">
-    © 2025 the alafia collective
+    © 2025 Alafia
   </footer>
 
   <script src="js/main.js?v=20260712-3"></script>

--- a/roster.html
+++ b/roster.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Alafia Collective – Current Roster</title>
+  <title>Alafia – Current Roster</title>
   <meta name="description"
-        content="Meet the current Alafia Collective artists shaping the future of African music." />
-  <meta property="og:title" content="Alafia Collective – Current Roster">
-  <meta property="og:description" content="Meet the current Alafia Collective artists shaping the future of African music.">
+        content="Meet the current Alafia artists shaping the future of African music." />
+  <meta property="og:title" content="Alafia – Current Roster">
+  <meta property="og:description" content="Meet the current Alafia artists shaping the future of African music.">
   <meta property="og:image" content="img/Trill-XOE.png">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="canonical" href="https://alafia.me/roster.html" />
@@ -22,7 +22,7 @@
 <body class="pt-16 bg-white text-neutral-900 antialiased">
   <header class="fixed top-0 left-0 z-50 w-full bg-white/90 backdrop-blur border-b border-neutral-200">
     <div class="flex items-center h-16 px-6 lg:px-8">
-      <a href="index.html" class="mr-auto text-base font-semibold tracking-tight lowercase">the alafia collective</a>
+      <a href="index.html" class="mr-auto text-base font-semibold tracking-tight lowercase">Alafia</a>
       <button id="navToggle" class="sm:hidden" aria-label="toggle menu"><i data-feather="menu"></i></button>
       <ul id="menu" class="hidden absolute top-full inset-x-0 z-40 flex-col gap-4 p-6 text-base font-medium bg-white border-b border-neutral-200 sm:static sm:flex sm:flex-row sm:gap-8 sm:p-0 sm:border-0 sm:bg-transparent sm:text-sm">
         <li><a href="roster.html"    class="hover:underline">Roster</a></li>
@@ -91,7 +91,7 @@
   </main>
 
   <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">
-    © 2025 the alafia collective
+    © 2025 Alafia
   </footer>
 
   <script src="js/main.js?v=20260712-3"></script>

--- a/roster.html
+++ b/roster.html
@@ -94,6 +94,6 @@
     © 2025 Alafia
   </footer>
 
-  <script src="js/main.js?v=20260712-3"></script>
+  <script src="js/main.js?v=20260712-4"></script>
 </body>
 </html>

--- a/rsvp-lagos.html
+++ b/rsvp-lagos.html
@@ -60,6 +60,6 @@
     © 2025 Alafia
   </footer>
 
-  <script src="js/main.js?v=20260712-3"></script>
+  <script src="js/main.js?v=20260712-4"></script>
 </body>
 </html>

--- a/rsvp-lagos.html
+++ b/rsvp-lagos.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Sounds of the City — Lagos · Q3 2025 – The Alafia Collective</title>
+  <title>Sounds of the City — Lagos · Q3 2025 – Alafia</title>
   <meta name="description"
-        content="RSVP to join The Alafia Collective live at Terra Kulture in Lagos." />
-  <meta property="og:title" content="Sounds of the City — Lagos · Q3 2025 – The Alafia Collective">
-  <meta property="og:description" content="RSVP to join The Alafia Collective live at Terra Kulture in Lagos.">
+        content="RSVP to join Alafia live at Terra Kulture in Lagos." />
+  <meta property="og:title" content="Sounds of the City — Lagos · Q3 2025 – Alafia">
+  <meta property="og:description" content="RSVP to join Alafia live at Terra Kulture in Lagos.">
   <meta property="og:image" content="img/Sounds.png">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="canonical" href="https://alafia.me/rsvp-lagos.html" />
@@ -22,7 +22,7 @@
 <body class="pt-16 bg-white text-neutral-900 antialiased">
   <header class="fixed top-0 left-0 z-50 w-full bg-white/90 backdrop-blur border-b border-neutral-200">
     <div class="flex items-center h-16 px-6 lg:px-8">
-      <a href="index.html" class="mr-auto text-base font-semibold tracking-tight lowercase">the alafia collective</a>
+      <a href="index.html" class="mr-auto text-base font-semibold tracking-tight lowercase">Alafia</a>
       <button id="navToggle" class="sm:hidden" aria-label="toggle menu"><i data-feather="menu"></i></button>
       <ul id="menu" class="hidden absolute top-full inset-x-0 z-40 flex-col gap-4 p-6 text-base font-medium bg-white border-b border-neutral-200 sm:static sm:flex sm:flex-row sm:gap-8 sm:p-0 sm:border-0 sm:bg-transparent sm:text-sm">
         <li><a href="roster.html"    class="hover:underline">Roster</a></li>
@@ -57,7 +57,7 @@
   </main>
 
   <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">
-    © 2025 the alafia collective
+    © 2025 Alafia
   </footer>
 
   <script src="js/main.js?v=20260712-3"></script>

--- a/whatsleft.html
+++ b/whatsleft.html
@@ -30,7 +30,7 @@
       <a href="https://boomplay.com/" target="_blank" rel="noopener noreferrer" class="w-full py-3 rounded-xl shadow font-semibold hover:opacity-90 transition flex items-center justify-center bg-blue-600 text-white" aria-label="Listen on Boomplay"><i data-feather="play" class="mr-2"></i>Boomplay</a>
     </div>
   </div>
-  <footer class="text-sm text-neutral-500">© 2025 the alafia collective</footer>
+  <footer class="text-sm text-neutral-500">© 2025 Alafia</footer>
   <script src="js/main.js?v=20260712-3"></script>
 </body>
 </html>

--- a/whatsleft.html
+++ b/whatsleft.html
@@ -31,6 +31,6 @@
     </div>
   </div>
   <footer class="text-sm text-neutral-500">© 2025 Alafia</footer>
-  <script src="js/main.js?v=20260712-3"></script>
+  <script src="js/main.js?v=20260712-4"></script>
 </body>
 </html>


### PR DESCRIPTION
Rebrands public-facing site text from “Alafia Collective” to “Alafia.”

- Updates header and footer wordmarks.
- Updates page titles, metadata, labels, article references, and copyright text.
- Leaves the approved X-mark asset unchanged.
- Refreshes the shared script version so the rebrand is visible immediately after deployment.

Validation: no remaining public `Alafia Collective` references across the static pages and shared script; JavaScript syntax checked.