### PR TITLE
Make hero headline explicitly white

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
     <div class="absolute inset-0 -z-10 bg-black"></div>
 
     <div class="max-w-5xl mx-auto px-6 lg:px-8 pt-52 pb-60 text-center">
-      <h1 class="text-4xl sm:text-7xl font-semibold tracking-tight leading-tight">
+      <h1 class="text-4xl sm:text-7xl font-semibold tracking-tight leading-tight" style="color: #f2f0eb !important; text-shadow: 0 4px 28px rgba(0, 0, 0, .72);">
         Powering Africa's Next<br>
         <span class="whitespace-nowrap">Global Icons</span>
       </h1>


### PR DESCRIPTION
Makes the main homepage headline — “Powering Africa's Next Global Icons” — explicitly white in the HTML with a subtle dark text shadow.

This prevents dark inherited styling or cached shared CSS from making the headline unreadable.

Validation: confirmed the homepage headline has the explicit high-contrast style.