### PR TITLE
Refresh roster and introduce selected projects

### DIFF
--- a/alumni.html
+++ b/alumni.html
@@ -60,6 +60,6 @@
   </main>
 
   <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">© 2025 Alafia</footer>
-  <script src="js/main.js?v=20260712-4"></script>
+  <script src="js/main.js?v=20260712-5"></script>
 </body>
 </html>

--- a/blog-post4.html
+++ b/blog-post4.html
@@ -101,6 +101,6 @@ Congratulations Oluwa lo shey (Congratulations, to me, it was God that did it)</
   <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">
     © 2025 Alafia
   </footer>
-  <script src="js/main.js?v=20260712-4"></script>
+  <script src="js/main.js?v=20260712-5"></script>
 </body>
 </html>

--- a/blog-post5.html
+++ b/blog-post5.html
@@ -44,6 +44,6 @@
   <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">
     © 2025 Alafia
   </footer>
-  <script src="js/main.js?v=20260712-4"></script>
+  <script src="js/main.js?v=20260712-5"></script>
 </body>
 </html>

--- a/blog-post6.html
+++ b/blog-post6.html
@@ -101,6 +101,6 @@ Yes, me I’m stacking my doe oh like Kilimanjaro</p>
   <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">
     © 2025 Alafia
   </footer>
-  <script src="js/main.js?v=20260712-4"></script>
+  <script src="js/main.js?v=20260712-5"></script>
 </body>
 </html>

--- a/blog.html
+++ b/blog.html
@@ -72,6 +72,6 @@
     © 2025 Alafia
   </footer>
 
-  <script src="js/main.js?v=20260712-4"></script>
+  <script src="js/main.js?v=20260712-5"></script>
 </body>
 </html>

--- a/event-1.html
+++ b/event-1.html
@@ -60,6 +60,6 @@
     © 2025 Alafia
   </footer>
 
-  <script src="js/main.js?v=20260712-4"></script>
+  <script src="js/main.js?v=20260712-5"></script>
 </body>
 </html>

--- a/events.html
+++ b/events.html
@@ -88,6 +88,6 @@
     © 2025 Alafia
   </footer>
 
-  <script src="js/main.js?v=20260712-4"></script>
+  <script src="js/main.js?v=20260712-5"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -95,9 +95,11 @@
     </article>
 
     <article>
-      <h2 class="text-xl font-semibold mb-4">Upcoming event</h2>
-      <a href="event-1.html">
-        <img src="img/Sounds.png" alt="upcoming event" class="w-full aspect-square object-cover border border-neutral-200">
+      <h2 class="text-xl font-semibold mb-4">Selected projects</h2>
+      <a href="projects.html" class="group flex aspect-square flex-col justify-between border border-neutral-200 bg-neutral-900 p-8 text-white">
+        <span class="text-xs font-medium uppercase tracking-widest text-white/60">Songs we have helped bring to life</span>
+        <span class="text-3xl font-semibold tracking-tight text-white">Explore our work across music.</span>
+        <span class="inline-flex items-center text-sm font-medium">View projects <i data-feather="arrow-up-right" class="ml-2 h-4 w-4"></i></span>
       </a>
     </article>
   </section>
@@ -150,14 +152,6 @@
         <a href="roster.html" class="group flex flex-col gap-4">
           <img src="img/EJ-FYA.png" alt="EJ Fya" class="aspect-square object-cover border border-neutral-200 group-hover:opacity-80 transition">
           <span class="font-medium">EJ Fya</span>
-        </a>
-        <a href="roster.html" class="group flex flex-col gap-4">
-          <img src="img/MideTheGOAT.png" alt="MideTheGOAT" class="aspect-square object-cover border border-neutral-200 group-hover:opacity-80 transition">
-          <span class="font-medium">MideTheGOAT</span>
-        </a>
-        <a href="roster.html" class="group flex flex-col gap-4">
-          <img src="img/Saezn.png" alt="Saezn" class="aspect-square object-cover border border-neutral-200 group-hover:opacity-80 transition">
-          <span class="font-medium">Saezn</span>
         </a>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -178,6 +178,6 @@
     © 2025 Alafia
   </footer>
 
-  <script src="js/main.js?v=20260712-4"></script>
+  <script src="js/main.js?v=20260712-5"></script>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -25,9 +25,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
     header {
       height: 76px;
-      background: rgba(242, 240, 235, .88) !important;
-      border-bottom-color: var(--alafia-line) !important;
-      backdrop-filter: blur(16px);
+      background: transparent !important;
+      border-bottom-color: transparent !important;
+      backdrop-filter: none;
     }
 
     header > div { height: 76px !important; }
@@ -80,6 +80,8 @@ document.addEventListener('DOMContentLoaded', () => {
     .alafia-brand--inverse { color: var(--alafia-paper) !important; }
     .alafia-brand--inverse .alafia-brand__mark { color: var(--alafia-paper); }
     .alafia-brand__wordmark { white-space: nowrap; }
+    header .alafia-brand { gap: 0; }
+    header .alafia-brand__wordmark { display: none; }
 
     .relative.isolate.overflow-hidden.min-h-screen {
       min-height: min(760px, calc(100vh - 76px)) !important;
@@ -292,6 +294,11 @@ document.addEventListener('DOMContentLoaded', () => {
     if (rosterItem) rosterItem.insertAdjacentElement('afterend', alumniItem);
     else menu.prepend(alumniItem);
   }
+  const projectsLink = menu?.querySelector('a[href="events.html"]');
+  if (projectsLink) {
+    projectsLink.href = 'projects.html';
+    projectsLink.textContent = 'Projects';
+  }
 
   const footer = document.querySelector('footer');
   if (footer) {
@@ -312,7 +319,7 @@ document.addEventListener('DOMContentLoaded', () => {
             '<li><a href="roster.html">Current Roster</a></li>' +
             '<li><a href="alumni.html">Alumni</a></li>' +
             '<li><a href="playlists.html">Playlists</a></li>' +
-            '<li><a href="events.html">Events</a></li>' +
+            '<li><a href="projects.html">Projects</a></li>' +
             '<li><a href="blog.html">Journal</a></li>' +
           '</ul>' +
         '</div>' +

--- a/playlists.html
+++ b/playlists.html
@@ -135,6 +135,6 @@
     © 2025 Alafia
   </footer>
 
-  <script src="js/main.js?v=20260712-4"></script>
+  <script src="js/main.js?v=20260712-5"></script>
 </body>
 </html>

--- a/projects.html
+++ b/projects.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Alafia – Selected Projects</title>
+  <meta name="description" content="Songs Alafia has helped bring to life across management, production, distribution and executive production." />
+  <meta property="og:title" content="Alafia – Selected Projects">
+  <meta property="og:description" content="Songs Alafia has helped bring to life across management, production, distribution and executive production.">
+  <meta property="og:image" content="img/rapid-fyah-cover.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="canonical" href="https://alafia.me/projects.html" />
+  <script>
+    tailwind.config = { theme: { extend: { fontFamily: { sans: ['Inter','system-ui','sans-serif'] } } } };
+  </script>
+  <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+  <script defer src="https://unpkg.com/feather-icons"></script>
+</head>
+<body class="pt-16 bg-white text-neutral-900 antialiased">
+  <header class="fixed top-0 left-0 z-50 w-full bg-white/90 backdrop-blur border-b border-neutral-200">
+    <div class="flex items-center h-16 px-6 lg:px-8">
+      <a href="index.html" class="mr-auto text-base font-semibold tracking-tight lowercase">Alafia</a>
+      <button id="navToggle" class="sm:hidden" aria-label="toggle menu"><i data-feather="menu"></i></button>
+      <ul id="menu" class="hidden absolute top-full inset-x-0 z-40 flex-col gap-4 p-6 text-base font-medium bg-white border-b border-neutral-200 sm:static sm:flex sm:flex-row sm:gap-8 sm:p-0 sm:border-0 sm:bg-transparent sm:text-sm">
+        <li><a href="roster.html" class="hover:underline">Roster</a></li>
+        <li><a href="playlists.html" class="hover:underline">Playlists</a></li>
+        <li><a href="events.html" class="hover:underline">Events</a></li>
+        <li><a href="blog.html" class="hover:underline">Blog</a></li>
+      </ul>
+    </div>
+  </header>
+
+  <main class="max-w-6xl mx-auto px-6 lg:px-8 pt-24 pb-32">
+    <h1 class="text-3xl font-semibold mb-4">Selected Projects</h1>
+    <p class="mb-12 text-neutral-700">Songs we have helped bring to life across management, production, distribution and executive production.</p>
+
+    <section class="grid gap-10 md:grid-cols-[minmax(0,1fr)_minmax(0,1.1fr)] md:items-center">
+      <img src="img/rapid-fyah-cover.svg" alt="Original Koffee and Skillibeng — RAPID FYAH cover art" class="w-full aspect-square object-cover border border-neutral-200">
+      <div>
+        <p class="text-sm text-neutral-600 mb-3">Original Koffee &amp; Skillibeng</p>
+        <h2 class="text-4xl font-semibold">RAPID FYAH</h2>
+        <p class="mt-4 text-neutral-700">Produced by EJ Fya</p>
+        <p class="mt-2 text-sm text-neutral-600">Role: Producer</p>
+        <a href="https://lnk.to/RAPIDFYAH" target="_blank" rel="noopener noreferrer" class="inline-flex items-center mt-6 text-sm font-medium hover:underline">
+          Stream across platforms <i data-feather="arrow-up-right" class="w-4 h-4 ml-2"></i>
+        </a>
+      </div>
+    </section>
+
+    <section class="mt-24 border border-neutral-200 p-8 md:p-12">
+      <p class="text-sm text-neutral-600 mb-3">Listen further</p>
+      <h2 class="text-3xl font-semibold">Alafia playlist</h2>
+      <p class="mt-4 max-w-2xl text-neutral-700">Explore the songs and artists in our orbit through the Alafia playlist.</p>
+      <a href="https://open.spotify.com/playlist/6xhAWwMGzB9z0goO5GKKcF?si=flK2lC_jQZ2zAMSFXLr3nQ&utm_source=copy-link&pi=NlLvomH5TwSNN" target="_blank" rel="noopener noreferrer" class="inline-flex items-center mt-6 text-sm font-medium hover:underline">
+        Open playlist on Spotify <i data-feather="arrow-up-right" class="w-4 h-4 ml-2"></i>
+      </a>
+    </section>
+  </main>
+
+  <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">© 2026 Alafia</footer>
+  <script src="js/main.js?v=20260712-4"></script>
+</body>
+</html>

--- a/projects.html
+++ b/projects.html
@@ -58,6 +58,6 @@
   </main>
 
   <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">© 2026 Alafia</footer>
-  <script src="js/main.js?v=20260712-4"></script>
+  <script src="js/main.js?v=20260712-5"></script>
 </body>
 </html>

--- a/roster.html
+++ b/roster.html
@@ -64,29 +64,6 @@
         </div>
       </div>
 
-      <!-- MideTheGOAT -->
-      <div class="flex flex-col gap-4">
-        <img src="img/MideTheGOAT.png" alt="MideTheGOAT" class="aspect-square object-cover border border-neutral-200">
-        <span class="font-medium">MideTheGOAT</span>
-        <span class="text-sm text-neutral-600">Nigeria - Afrobeats, R&amp;B, Rap</span>
-        <div class="flex gap-4 mt-2 text-neutral-500">
-          <a href="#" aria-label="Spotify"><i data-feather="music"></i></a>
-          <a href="#" aria-label="Instagram"><i data-feather="instagram"></i></a>
-          <a href="#" aria-label="X"><i data-feather="twitter"></i></a>
-        </div>
-      </div>
-
-      <!-- Saezn -->
-      <div class="flex flex-col gap-4">
-        <img src="img/Saezn.png" alt="Saezn" class="aspect-square object-cover border border-neutral-200">
-        <span class="font-medium">Saezn</span>
-        <span class="text-sm text-neutral-600">Nigeria - R&amp;B, Soul, Afrobeats</span>
-        <div class="flex gap-4 mt-2 text-neutral-500">
-          <a href="#" aria-label="Spotify"><i data-feather="music"></i></a>
-          <a href="#" aria-label="Instagram"><i data-feather="instagram"></i></a>
-          <a href="#" aria-label="X"><i data-feather="twitter"></i></a>
-        </div>
-      </div>
     </div>
   </main>
 

--- a/roster.html
+++ b/roster.html
@@ -71,6 +71,6 @@
     © 2025 Alafia
   </footer>
 
-  <script src="js/main.js?v=20260712-4"></script>
+  <script src="js/main.js?v=20260712-5"></script>
 </body>
 </html>

--- a/rsvp-lagos.html
+++ b/rsvp-lagos.html
@@ -60,6 +60,6 @@
     © 2025 Alafia
   </footer>
 
-  <script src="js/main.js?v=20260712-4"></script>
+  <script src="js/main.js?v=20260712-5"></script>
 </body>
 </html>

--- a/whatsleft.html
+++ b/whatsleft.html
@@ -31,6 +31,6 @@
     </div>
   </div>
   <footer class="text-sm text-neutral-500">© 2025 Alafia</footer>
-  <script src="js/main.js?v=20260712-4"></script>
+  <script src="js/main.js?v=20260712-5"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replaces the Events navigation destination with a new **Projects** page for music Alafia has helped bring to life.
- Adds RAPID FYAH (Original Koffee & Skillibeng), with EJ Fya credited as producer and a streaming link.
- Adds the supplied Spotify playlist.
- Removes MideTheGOAT and Saezn from the roster and homepage; Tommy Darrel can be added once his avatar arrives.
- Simplifies the top bar to an icon-only, transparent brand treatment and updates the footer navigation.
- Bumps the site script version so the latest header/navigation changes bypass stale browser caches.