### PR TITLE
Refocus homepage on lasting careers

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Alafia – Powering Africa's Next Generation of Global Icons</title>
+  <title>Alafia – Building Lasting Careers in African Music</title>
   <meta name="description"
-        content="Alafia provides integrated management, label services and publishing for emerging African artists. Explore our roster, playlists and events." />
-  <meta property="og:title" content="Alafia – Powering Africa's Next Generation of Global Icons">
-  <meta property="og:description" content="Alafia provides integrated management, label services and publishing for emerging African artists. Explore our roster, playlists and events.">
+        content="Alafia builds lasting careers for African artists, songwriters and producers through management, label services, publishing and strategic partnerships." />
+  <meta property="og:title" content="Alafia – Building Lasting Careers in African Music">
+  <meta property="og:description" content="Alafia builds lasting careers for African artists, songwriters and producers through management, label services, publishing and strategic partnerships.">
   <meta property="og:image" content="img/Announcement.png">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="canonical" href="https://alafia.me/" />
@@ -47,14 +47,14 @@
 
     <div class="max-w-5xl mx-auto px-6 lg:px-8 pt-52 pb-60 text-center">
       <h1 class="text-4xl sm:text-7xl font-semibold tracking-tight leading-tight" style="color: #f2f0eb !important; text-shadow: 0 4px 28px rgba(0, 0, 0, .72);">
-        Powering Africa's Next<br>
-        <span class="whitespace-nowrap">Global Icons</span>
+        Building lasting careers<br>
+        <span class="whitespace-nowrap">for African music.</span>
       </h1>
       <p class="mt-8 text-lg leading-8 text-white">
-        Your full-suite partner for commercial success.
-        <span class="block text-xl sm:text-2xl mt-2">We provide integrated
-        management, label services, and publishing solutions that elevate
-        African talent into global powerhouses.</span>
+        For artists, songwriters and producers with a long view.
+        <span class="block text-xl sm:text-2xl mt-2">Alafia brings management,
+        label services, publishing and strategic partnerships together to turn
+        creative momentum into enduring, global careers.</span>
       </p>
     </div>
   </section>
@@ -62,15 +62,14 @@
   <!-- Mission -->
   <section class="py-24">
     <div class="max-w-4xl mx-auto px-6 lg:px-8 text-center">
-      <h2 class="text-2xl font-semibold mb-6">The Paradox We Address</h2>
+      <h2 class="text-2xl font-semibold mb-6">Built for the long run</h2>
       <p class="text-lg leading-8 text-neutral-700 mb-8">
-        Creating music is easier than ever, but <strong>breaking music is harder than ever</strong>. 
-        African artists have immense potential but face fragmented pathways to global success.
+        Great music needs more than a moment. It needs a team, a plan and the right
+        opportunities to become a career that lasts.
       </p>
       <p class="text-base leading-7 text-neutral-600">
-        We bridge the gap between local talent and global aspirations through strategic guidance, 
-        industry access, and synergistic partnerships that turn creative excellence into 
-        sustainable careers.
+        Alafia connects creative talent with the strategic guidance, industry access and
+        commercial infrastructure needed to grow from local momentum into a sustainable global career.
       </p>
     </div>
   </section>


### PR DESCRIPTION
Updates the homepage hero to lead with Alafia's career-building purpose, clearly names management, label services, publishing and partnerships, and aligns the opening mission copy and social metadata.