### PR TITLE
Polish hero header and homepage roster

### DIFF
--- a/alumni.html
+++ b/alumni.html
@@ -67,6 +67,6 @@
   </main>
 
   <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">© 2025 Alafia</footer>
-  <script src="js/main.js?v=20260712-6"></script>
+  <script src="js/main.js?v=20260712-7"></script>
 </body>
 </html>

--- a/blog-post4.html
+++ b/blog-post4.html
@@ -101,6 +101,6 @@ Congratulations Oluwa lo shey (Congratulations, to me, it was God that did it)</
   <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">
     © 2025 Alafia
   </footer>
-  <script src="js/main.js?v=20260712-6"></script>
+  <script src="js/main.js?v=20260712-7"></script>
 </body>
 </html>

--- a/blog-post5.html
+++ b/blog-post5.html
@@ -44,6 +44,6 @@
   <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">
     © 2025 Alafia
   </footer>
-  <script src="js/main.js?v=20260712-6"></script>
+  <script src="js/main.js?v=20260712-7"></script>
 </body>
 </html>

--- a/blog-post6.html
+++ b/blog-post6.html
@@ -101,6 +101,6 @@ Yes, me I’m stacking my doe oh like Kilimanjaro</p>
   <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">
     © 2025 Alafia
   </footer>
-  <script src="js/main.js?v=20260712-6"></script>
+  <script src="js/main.js?v=20260712-7"></script>
 </body>
 </html>

--- a/blog.html
+++ b/blog.html
@@ -72,6 +72,6 @@
     © 2025 Alafia
   </footer>
 
-  <script src="js/main.js?v=20260712-6"></script>
+  <script src="js/main.js?v=20260712-7"></script>
 </body>
 </html>

--- a/event-1.html
+++ b/event-1.html
@@ -60,6 +60,6 @@
     © 2025 Alafia
   </footer>
 
-  <script src="js/main.js?v=20260712-6"></script>
+  <script src="js/main.js?v=20260712-7"></script>
 </body>
 </html>

--- a/events.html
+++ b/events.html
@@ -88,6 +88,6 @@
     © 2025 Alafia
   </footer>
 
-  <script src="js/main.js?v=20260712-6"></script>
+  <script src="js/main.js?v=20260712-7"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -173,6 +173,6 @@
     © 2025 Alafia
   </footer>
 
-  <script src="js/main.js?v=20260712-6"></script>
+  <script src="js/main.js?v=20260712-7"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -136,23 +136,19 @@
     </div>
   </section>
 
-  <!-- Featured artists -->
-  <section class="py-24">
-    <div class="max-w-6xl mx-auto px-6 lg:px-8">
-      <h2 class="text-2xl font-semibold mb-4 text-center">Our Collective</h2>
-      <p class="text-center text-neutral-600 mb-12 max-w-2xl mx-auto">
-        Artists, songwriters, and producers collaborating to create the next wave of global African music
+  <!-- Current roster -->
+  <section class="border-t border-neutral-200 py-20">
+    <div class="max-w-3xl mx-auto px-6 lg:px-8 text-center">
+      <p class="text-xs font-medium uppercase tracking-widest text-neutral-500 mb-4">Current roster</p>
+      <h2 class="text-3xl font-semibold tracking-tight">Artists building their next chapter.</h2>
+      <p class="mt-5 text-lg leading-8 text-neutral-600">
+        Alafia currently represents <a href="roster.html" class="font-medium text-neutral-900 underline decoration-neutral-300 underline-offset-4 hover:decoration-neutral-900">Trill XOE</a>
+        and <a href="roster.html" class="font-medium text-neutral-900 underline decoration-neutral-300 underline-offset-4 hover:decoration-neutral-900">EJ Fya</a>,
+        supporting their work through management, label services and publishing.
       </p>
-      <div class="grid gap-12 sm:grid-cols-2 lg:grid-cols-4">
-        <a href="roster.html" class="group flex flex-col gap-4">
-          <img src="img/Trill-XOE.png" alt="Trill XOE" class="aspect-square object-cover border border-neutral-200 group-hover:opacity-80 transition">
-          <span class="font-medium">Trill XOE</span>
-        </a>
-        <a href="roster.html" class="group flex flex-col gap-4">
-          <img src="img/EJ-FYA.png" alt="EJ Fya" class="aspect-square object-cover border border-neutral-200 group-hover:opacity-80 transition">
-          <span class="font-medium">EJ Fya</span>
-        </a>
-      </div>
+      <a href="roster.html" class="inline-flex items-center mt-8 text-sm font-medium hover:underline">
+        Meet the roster <i data-feather="arrow-up-right" class="w-4 h-4 ml-2"></i>
+      </a>
     </div>
   </section>
 

--- a/js/main.js
+++ b/js/main.js
@@ -24,13 +24,14 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     header {
-      height: 76px;
-      background: transparent !important;
-      border-bottom-color: transparent !important;
-      backdrop-filter: none;
+      height: 64px;
+      background: var(--alafia-paper) !important;
+      border: 0 !important;
+      box-shadow: none !important;
+      backdrop-filter: none !important;
     }
 
-    header > div { height: 76px !important; }
+    header > div { height: 64px !important; }
     header a:not(.alafia-brand) {
       position: relative;
       color: var(--alafia-ink) !important;
@@ -261,7 +262,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     @media (max-width: 639px) {
       header, header > div { height: 66px !important; }
-      body { padding-top: 66px !important; }
+      body { padding-top: 64px !important; }
       #menu {
         top: 66px !important;
         background: var(--alafia-paper) !important;

--- a/playlists.html
+++ b/playlists.html
@@ -135,6 +135,6 @@
     © 2025 Alafia
   </footer>
 
-  <script src="js/main.js?v=20260712-6"></script>
+  <script src="js/main.js?v=20260712-7"></script>
 </body>
 </html>

--- a/projects.html
+++ b/projects.html
@@ -58,6 +58,6 @@
   </main>
 
   <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">© 2026 Alafia</footer>
-  <script src="js/main.js?v=20260712-6"></script>
+  <script src="js/main.js?v=20260712-7"></script>
 </body>
 </html>

--- a/roster.html
+++ b/roster.html
@@ -71,6 +71,6 @@
     © 2025 Alafia
   </footer>
 
-  <script src="js/main.js?v=20260712-6"></script>
+  <script src="js/main.js?v=20260712-7"></script>
 </body>
 </html>

--- a/rsvp-lagos.html
+++ b/rsvp-lagos.html
@@ -60,6 +60,6 @@
     © 2025 Alafia
   </footer>
 
-  <script src="js/main.js?v=20260712-6"></script>
+  <script src="js/main.js?v=20260712-7"></script>
 </body>
 </html>

--- a/whatsleft.html
+++ b/whatsleft.html
@@ -31,6 +31,6 @@
     </div>
   </div>
   <footer class="text-sm text-neutral-500">© 2025 Alafia</footer>
-  <script src="js/main.js?v=20260712-6"></script>
+  <script src="js/main.js?v=20260712-7"></script>
 </body>
 </html>


### PR DESCRIPTION
## Fixes
- Aligns the fixed header to the page's 64px top spacing so it no longer overlaps the hero.
- Removes the header blur and shadow treatment that created the halo at the top of the hero.
- Replaces the sparse two-card homepage roster grid with a concise, centered current-roster statement linking to Trill XOE, EJ Fya and the full roster.
- Bumps the script version so visitors receive the visual fix instead of a cached stylesheet.