### PR TITLE
Point Projects page to approved playlists

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -49,16 +49,11 @@
 
     <section class="mt-24 border border-neutral-200 p-8 md:p-12">
       <p class="text-sm text-neutral-600 mb-3">Listen further</p>
-      <h2 class="text-3xl font-semibold">Alafia playlist</h2>
-      <p class="mt-4 max-w-2xl text-neutral-700">Explore the songs and artists in our orbit through the Alafia playlist.</p>
-      <div class="flex flex-wrap gap-x-6 gap-y-3 mt-6">
-        <a href="https://open.spotify.com/playlist/6xhAWwMGzB9z0goO5GKKcF?si=flK2lC_jQZ2zAMSFXLr3nQ&utm_source=copy-link&pi=NlLvomH5TwSNN" target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-sm font-medium hover:underline">
-          Open playlist on Spotify <i data-feather="arrow-up-right" class="w-4 h-4 ml-2"></i>
-        </a>
-        <a href="https://music.apple.com/ng/playlist/songs-during-alafias-regime/pl.u-zPyLLEvCZyXpmey" target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-sm font-medium hover:underline">
-          Open playlist on Apple Music <i data-feather="arrow-up-right" class="w-4 h-4 ml-2"></i>
-        </a>
-      </div>
+      <h2 class="text-3xl font-semibold">Alafia playlists</h2>
+      <p class="mt-4 max-w-2xl text-neutral-700">Explore our curated playlists, with Spotify and Apple Music embeds in one place.</p>
+      <a href="playlists.html" class="inline-flex items-center mt-6 text-sm font-medium hover:underline">
+        Explore playlists <i data-feather="arrow-up-right" class="w-4 h-4 ml-2"></i>
+      </a>
     </section>
   </main>
 


### PR DESCRIPTION
Removes the incorrect external Spotify and Apple Music playlist links from the Projects page. The Listen further section now links only to playlists.html, which contains the approved platform embeds.