### PR TITLE
Refocus hero on artist breakthrough and add favicon

### DIFF
--- a/alumni.html
+++ b/alumni.html
@@ -4,6 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Alafia – Alumni</title>
+  <link rel="icon" type="image/svg+xml" href="img/alafia-x-mark-black.svg" />
+
   <meta name="description" content="Artists who have been part of the Alafia story." />
   <meta property="og:title" content="Alafia – Alumni">
   <meta property="og:description" content="Artists who have been part of the Alafia story.">

--- a/blog-post4.html
+++ b/blog-post4.html
@@ -4,6 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Introducing Rydm &amp; Alafia: My First Jam Session – Alafia Blog</title>
+  <link rel="icon" type="image/svg+xml" href="img/alafia-x-mark-black.svg" />
+
   <meta name="description" content="Temitope recounts meeting Rydm Jay and the jam sessions that sparked Alafia." />
   <meta property="og:title" content="Introducing Rydm & Alafia: My First Jam Session – Alafia Blog">
   <meta property="og:description" content="Temitope recounts meeting Rydm Jay and the jam sessions that sparked Alafia.">

--- a/blog-post5.html
+++ b/blog-post5.html
@@ -4,6 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>From Consulting to the Alafia – Alafia Blog</title>
+  <link rel="icon" type="image/svg+xml" href="img/alafia-x-mark-black.svg" />
+
   <meta name="description" content="Temitope shares his path from management consulting ambitions to launching Alafia." />
   <link rel="canonical" href="https://alafia.me/blog-post5.html" />
   <meta property="og:title" content="From Consulting to the Alafia – Alafia Blog">

--- a/blog-post6.html
+++ b/blog-post6.html
@@ -4,6 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Gospel Artists With A Popstar Calling – Alafia Blog</title>
+  <link rel="icon" type="image/svg+xml" href="img/alafia-x-mark-black.svg" />
+
   <meta name="description" content="Your Fave explores spiritual themes in Black Sherif's music and how it inspires him." />
   <link rel="canonical" href="https://alafia.me/blog-post6.html" />
   <meta property="og:title" content="Gospel Artists With A Popstar Calling – Alafia Blog">

--- a/blog.html
+++ b/blog.html
@@ -4,6 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Alafia Insights – Inside Africa's Music Evolution</title>
+  <link rel="icon" type="image/svg+xml" href="img/alafia-x-mark-black.svg" />
+
   <meta name="description"
         content="Thought‑starters on artistry, tech and the business of African music." />
   <meta property="og:title" content="Alafia Insights – Inside Africa's Music Evolution">

--- a/event-1.html
+++ b/event-1.html
@@ -4,6 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Sounds of the City — Accra · Q4 2025 – Alafia</title>
+  <link rel="icon" type="image/svg+xml" href="img/alafia-x-mark-black.svg" />
+
   <meta name="description"
         content="Join Nikita Kering’, Trill Xoe and Mide The Goat live in Accra to celebrate the future of African music." />
   <meta property="og:title" content="Sounds of the City — Accra · 12 Sep 2025 – Alafia">

--- a/events.html
+++ b/events.html
@@ -4,6 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Alafia Live – Showcasing Tomorrow's Global African Icons</title>
+  <link rel="icon" type="image/svg+xml" href="img/alafia-x-mark-black.svg" />
+
   <meta name="description"
         content="Experience Alafia talent on stage from Lagos block parties to global festivals. See upcoming shows." />
   <meta property="og:title" content="Alafia Live – Showcasing Tomorrow's Global African Icons">

--- a/index.html
+++ b/index.html
@@ -3,14 +3,15 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Alafia – Building Lasting Careers in African Music</title>
+  <title>Alafia – The Full Suite Behind Breakthrough Artists</title>
   <meta name="description"
-        content="Alafia builds lasting careers for African artists, songwriters and producers through management, label services, publishing and strategic partnerships." />
-  <meta property="og:title" content="Alafia – Building Lasting Careers in African Music">
-  <meta property="og:description" content="Alafia builds lasting careers for African artists, songwriters and producers through management, label services, publishing and strategic partnerships.">
+        content="Alafia provides the full suite of artist services—from discovery and creative support to marketing and distribution—built to help breakthrough artists grow." />
+  <meta property="og:title" content="Alafia – The Full Suite Behind Breakthrough Artists">
+  <meta property="og:description" content="Alafia provides the full suite of artist services—from discovery and creative support to marketing and distribution—built to help breakthrough artists grow.">
   <meta property="og:image" content="img/Announcement.png">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="canonical" href="https://alafia.me/" />
+  <link rel="icon" type="image/svg+xml" href="img/alafia-x-mark-black.svg" />
 
   <script>
     tailwind.config = {
@@ -47,14 +48,14 @@
 
     <div class="max-w-5xl mx-auto px-6 lg:px-8 pt-52 pb-60 text-center">
       <h1 class="text-4xl sm:text-7xl font-semibold tracking-tight leading-tight" style="color: #f2f0eb !important; text-shadow: 0 4px 28px rgba(0, 0, 0, .72);">
-        Building lasting careers<br>
-        <span class="whitespace-nowrap">for African music.</span>
+        The full suite behind<br>
+        <span class="whitespace-nowrap">Africa's next breakthrough artists.</span>
       </h1>
       <p class="mt-8 text-lg leading-8 text-white">
-        For artists, songwriters and producers with a long view.
-        <span class="block text-xl sm:text-2xl mt-2">Alafia brings management,
-        label services, publishing and strategic partnerships together to turn
-        creative momentum into enduring, global careers.</span>
+        Built around artists from day one.
+        <span class="block text-xl sm:text-2xl mt-2">From discovery and creative support
+        to marketing, distribution and beyond, Alafia brings the people, strategy and
+        services artists need to break through.</span>
       </p>
     </div>
   </section>

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
     <div class="max-w-5xl mx-auto px-6 lg:px-8 pt-52 pb-60 text-center">
       <h1 class="text-4xl sm:text-7xl font-semibold tracking-tight leading-tight" style="color: #f2f0eb !important; text-shadow: 0 4px 28px rgba(0, 0, 0, .72);">
         The full suite behind<br>
-        <span class="whitespace-nowrap">Africa's next breakthrough artists.</span>
+        <span>Africa's next breakthrough artists.</span>
       </h1>
       <p class="mt-8 text-lg leading-8 text-white">
         Built around artists from day one.

--- a/playlists.html
+++ b/playlists.html
@@ -4,6 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Alafia Curated – Essential Sounds from Africa's Rising Stars</title>
+  <link rel="icon" type="image/svg+xml" href="img/alafia-x-mark-black.svg" />
+
   <meta name="description"
         content="Explore curated journeys through Afrobeats, Alté and everything in-between." />
   <meta property="og:title" content="Alafia Curated – Essential Sounds from Africa's Rising Stars">

--- a/projects.html
+++ b/projects.html
@@ -4,6 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Alafia – Selected Projects</title>
+  <link rel="icon" type="image/svg+xml" href="img/alafia-x-mark-black.svg" />
+
   <meta name="description" content="Songs Alafia has helped bring to life across management, production, distribution and executive production." />
   <meta property="og:title" content="Alafia – Selected Projects">
   <meta property="og:description" content="Songs Alafia has helped bring to life across management, production, distribution and executive production.">

--- a/roster.html
+++ b/roster.html
@@ -4,6 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Alafia – Current Roster</title>
+  <link rel="icon" type="image/svg+xml" href="img/alafia-x-mark-black.svg" />
+
   <meta name="description"
         content="Meet the current Alafia artists shaping the future of African music." />
   <meta property="og:title" content="Alafia – Current Roster">

--- a/rsvp-lagos.html
+++ b/rsvp-lagos.html
@@ -4,6 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Sounds of the City — Lagos · Q3 2025 – Alafia</title>
+  <link rel="icon" type="image/svg+xml" href="img/alafia-x-mark-black.svg" />
+
   <meta name="description"
         content="RSVP to join Alafia live at Terra Kulture in Lagos." />
   <meta property="og:title" content="Sounds of the City — Lagos · Q3 2025 – Alafia">

--- a/whatsleft.html
+++ b/whatsleft.html
@@ -4,6 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>alafia – What’s Left?</title>
+  <link rel="icon" type="image/svg+xml" href="img/alafia-x-mark-black.svg" />
+
   <meta name="description" content="Stream Rydm's EP - What's Left?" />
   <meta property="og:title" content="alafia – What’s Left?">
   <meta property="og:description" content="Stream Rydm's EP - What's Left?">


### PR DESCRIPTION
## Updates
- Replaces the “lasting careers” hero with a clearer statement of Alafia's purpose: the full suite behind Africa's next breakthrough artists.
- Names the core services in the hero: discovery, creative support, marketing, distribution and beyond.
- Aligns the home page's title and social descriptions with that positioning.
- Adds the supplied Alafia black mark as the favicon across the site, so browser tabs show the brand icon.