### PR TITLE
Add a detailed Alafia services page

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,6 +134,11 @@
             </p>
         </div>
       </div>
+      <div class="mt-12 text-center">
+        <a href="services.html" class="inline-flex items-center text-sm font-medium hover:underline">
+          Explore our services <i data-feather="arrow-up-right" class="w-4 h-4 ml-2"></i>
+        </a>
+      </div>
     </div>
   </section>
 

--- a/js/main.js
+++ b/js/main.js
@@ -295,6 +295,15 @@ document.addEventListener('DOMContentLoaded', () => {
     if (rosterItem) rosterItem.insertAdjacentElement('afterend', alumniItem);
     else menu.prepend(alumniItem);
   }
+  if (menu && !menu.querySelector('a[href="services.html"]')) {
+    const servicesItem = document.createElement('li');
+    servicesItem.innerHTML = '<a href="services.html" class="hover:underline">Services</a>';
+    const alumniItem = menu.querySelector('a[href="alumni.html"]')?.closest('li');
+    const rosterItem = menu.querySelector('a[href="roster.html"]')?.closest('li');
+    if (alumniItem) alumniItem.insertAdjacentElement('afterend', servicesItem);
+    else if (rosterItem) rosterItem.insertAdjacentElement('afterend', servicesItem);
+    else menu.prepend(servicesItem);
+  }
   const projectsLink = menu?.querySelector('a[href="events.html"]');
   if (projectsLink) {
     projectsLink.href = 'projects.html';
@@ -318,6 +327,7 @@ document.addEventListener('DOMContentLoaded', () => {
           '<p class="alafia-footer__label">Explore</p>' +
           '<ul class="alafia-footer__links">' +
             '<li><a href="roster.html">Current Roster</a></li>' +
+            '<li><a href="services.html">Services</a></li>' +
             '<li><a href="alumni.html">Alumni</a></li>' +
             '<li><a href="playlists.html">Playlists</a></li>' +
             '<li><a href="projects.html">Projects</a></li>' +

--- a/services.html
+++ b/services.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Alafia – Artist Management, Label Services &amp; Publishing</title>
+  <link rel="icon" type="image/svg+xml" href="img/alafia-x-mark-black.svg" />
+  <meta name="description" content="Alafia connects artist management, creative support, label services, distribution and publishing for African artists, songwriters and producers." />
+  <meta property="og:title" content="Alafia – Artist Services">
+  <meta property="og:description" content="Artist management, creative support, label services, distribution and publishing—connected around the work.">
+  <meta property="og:image" content="img/rapid-fyah-cover.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="canonical" href="https://alafia.me/services.html" />
+  <script>
+    tailwind.config = { theme: { extend: { fontFamily: { sans: ['Inter','system-ui','sans-serif'] } } } };
+  </script>
+  <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+  <script defer src="https://unpkg.com/feather-icons"></script>
+</head>
+<body class="pt-16 bg-white text-neutral-900 antialiased">
+  <header class="fixed top-0 left-0 z-50 w-full bg-white/90 backdrop-blur border-b border-neutral-200">
+    <div class="flex items-center h-16 px-6 lg:px-8">
+      <a href="index.html" class="mr-auto text-base font-semibold tracking-tight lowercase">Alafia</a>
+      <button id="navToggle" class="sm:hidden" aria-label="toggle menu"><i data-feather="menu"></i></button>
+      <ul id="menu" class="hidden absolute top-full inset-x-0 z-40 flex-col gap-4 p-6 text-base font-medium bg-white border-b border-neutral-200 sm:static sm:flex sm:flex-row sm:gap-8 sm:p-0 sm:border-0 sm:bg-transparent sm:text-sm">
+        <li><a href="roster.html" class="hover:underline">Roster</a></li>
+        <li><a href="playlists.html" class="hover:underline">Playlists</a></li>
+        <li><a href="events.html" class="hover:underline">Events</a></li>
+        <li><a href="blog.html" class="hover:underline">Blog</a></li>
+      </ul>
+    </div>
+  </header>
+
+  <main>
+    <section class="border-b border-neutral-200 px-6 py-20 sm:py-28 lg:px-8">
+      <div class="mx-auto max-w-6xl">
+        <p class="text-xs font-medium uppercase tracking-widest text-neutral-500">What we do</p>
+        <h1 class="mt-5 max-w-4xl text-5xl font-semibold tracking-tight sm:text-6xl">Artist services, connected.</h1>
+        <p class="mt-7 max-w-2xl text-lg leading-8 text-neutral-700">
+          Alafia brings discovery, creative support, management, marketing, distribution and publishing into one connected team—built around the work an artist needs at each stage.
+        </p>
+      </div>
+    </section>
+
+    <section class="mx-auto max-w-6xl px-6 py-20 lg:px-8">
+      <div class="grid gap-16">
+        <article class="grid gap-8 border-b border-neutral-200 pb-16 lg:grid-cols-[minmax(0,.8fr)_minmax(0,1.2fr)]">
+          <div>
+            <p class="text-xs font-medium uppercase tracking-widest text-neutral-500">01</p>
+            <h2 class="mt-4 text-3xl font-semibold tracking-tight">Management &amp; Representation</h2>
+          </div>
+          <div>
+            <p class="text-lg leading-8 text-neutral-700">We help shape the decisions around an artist’s career: priorities, partnerships, opportunities and the team around the work.</p>
+            <h3 class="mt-8 text-sm font-semibold uppercase tracking-wider">How we deliver</h3>
+            <ul class="mt-4 grid gap-4 text-sm leading-6 text-neutral-600 sm:grid-cols-3">
+              <li><span class="block font-medium text-neutral-900">Career strategy</span>Goals, release priorities and timing that support the bigger picture.</li>
+              <li><span class="block font-medium text-neutral-900">Partnership development</span>Brands, collaborators and opportunities that fit the artist’s direction.</li>
+              <li><span class="block font-medium text-neutral-900">Team coordination</span>Keeping the key people and conversations aligned around each move.</li>
+            </ul>
+          </div>
+        </article>
+
+        <article class="grid gap-8 border-b border-neutral-200 pb-16 lg:grid-cols-[minmax(0,.8fr)_minmax(0,1.2fr)]">
+          <div>
+            <p class="text-xs font-medium uppercase tracking-widest text-neutral-500">02</p>
+            <h2 class="mt-4 text-3xl font-semibold tracking-tight">Label &amp; Artist Services</h2>
+          </div>
+          <div>
+            <p class="text-lg leading-8 text-neutral-700">We support the journey from an early idea to a release that can find its audience—without treating every artist or project the same way.</p>
+            <h3 class="mt-8 text-sm font-semibold uppercase tracking-wider">How we deliver</h3>
+            <ul class="mt-4 grid gap-4 text-sm leading-6 text-neutral-600 sm:grid-cols-3">
+              <li><span class="block font-medium text-neutral-900">Discovery &amp; A&amp;R</span>Identifying potential, repertoire and a creative direction worth building on.</li>
+              <li><span class="block font-medium text-neutral-900">Creative support</span>Connecting the right writers, producers and collaborators, then shaping the assets around the work.</li>
+              <li><span class="block font-medium text-neutral-900">Campaigns &amp; distribution</span>Release planning, marketing narrative and delivery coordination for each project.</li>
+            </ul>
+          </div>
+        </article>
+
+        <article class="grid gap-8 lg:grid-cols-[minmax(0,.8fr)_minmax(0,1.2fr)]">
+          <div>
+            <p class="text-xs font-medium uppercase tracking-widest text-neutral-500">03</p>
+            <h2 class="mt-4 text-3xl font-semibold tracking-tight">Publishing &amp; Rights</h2>
+          </div>
+          <div>
+            <p class="text-lg leading-8 text-neutral-700">We help creators make their music work as a long-term asset, with thoughtful attention to compositions, rights and commercial opportunity.</p>
+            <h3 class="mt-8 text-sm font-semibold uppercase tracking-wider">How we deliver</h3>
+            <ul class="mt-4 grid gap-4 text-sm leading-6 text-neutral-600 sm:grid-cols-3">
+              <li><span class="block font-medium text-neutral-900">Composition strategy</span>Supporting the catalogue, collaborations and opportunities around the songs.</li>
+              <li><span class="block font-medium text-neutral-900">Rights &amp; royalty oversight</span>Helping coordinate rights management and royalty collection.</li>
+              <li><span class="block font-medium text-neutral-900">Sync &amp; commercial opportunities</span>Positioning compositions for relevant placements and partnerships.</li>
+            </ul>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="bg-neutral-950 px-6 py-20 text-white lg:px-8">
+      <div class="mx-auto grid max-w-6xl gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+        <div>
+          <p class="text-xs font-medium uppercase tracking-widest text-neutral-400">How we work</p>
+          <h2 class="mt-5 text-3xl font-semibold tracking-tight">The right support, at the right stage.</h2>
+        </div>
+        <ol class="grid gap-5 text-sm leading-6 text-neutral-300 sm:grid-cols-2">
+          <li><span class="block font-medium text-white">Listen</span>We begin with the artist, the work and the opportunity in front of them.</li>
+          <li><span class="block font-medium text-white">Build a strategy</span>We define a focused path instead of applying a fixed formula.</li>
+          <li><span class="block font-medium text-white">Assemble the service mix</span>Management, creative, marketing, distribution and publishing come together where useful.</li>
+          <li><span class="block font-medium text-white">Deliver and learn</span>We bring the plan to life, then use what each release teaches us to inform the next one.</li>
+        </ol>
+      </div>
+    </section>
+
+    <section class="mx-auto max-w-6xl px-6 py-20 text-center lg:px-8">
+      <h2 class="text-3xl font-semibold tracking-tight">See the work in motion.</h2>
+      <p class="mx-auto mt-4 max-w-xl text-neutral-600">Explore the artists and projects that make up the Alafia story.</p>
+      <div class="mt-8 flex flex-wrap justify-center gap-x-7 gap-y-4 text-sm font-medium">
+        <a href="roster.html" class="hover:underline">Meet the roster <span aria-hidden="true">↗</span></a>
+        <a href="projects.html" class="hover:underline">Explore projects <span aria-hidden="true">↗</span></a>
+      </div>
+    </section>
+  </main>
+
+  <footer class="border-t border-neutral-200 py-10 text-center text-sm text-neutral-500">© 2026 Alafia</footer>
+  <script src="js/main.js?v=20260714-9"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated Services page explaining management, label and artist services, and publishing
- outline how Alafia delivers each service without overclaiming
- link Services from the homepage, navigation, and footer

## Checks
- verified the new page metadata, three service sections, delivery detail, navigation/footer links, and balanced section markup